### PR TITLE
fix(ci): test `maili-provider` with `no_std`

### DIFF
--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -27,3 +27,7 @@ alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
 # misc
 async-trait.workspace = true
+
+[dev-dependencies]
+# `serde` must be explicitly enabled to test with `--no-default-features`
+maili-protocol = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
Explicitly enables `maili-protocol/serde` in `maili-provider` dev deps