### PR TITLE
chore: Maili Re-export Crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # Workspace
 maili-protocol = { version = "0.1.0", path = "crates/protocol", default-features = false }
 maili-provider = { version = "0.1.0", path = "crates/provider", default-features = false }
-maili-registry = { version = "0.9.1", path = "crates/registry", default-features = false }
+maili-registry = { version = "0.1.0", path = "crates/registry", default-features = false }
 
 # OP-Alloy
 op-alloy-genesis = { version = "0.9.0", default-features = false }

--- a/crates/maili/Cargo.toml
+++ b/crates/maili/Cargo.toml
@@ -32,9 +32,9 @@ std = [
 ]
 
 full = [
-  "maili-protocol",
-  "maili-provider",
-  "maili-registry",
+  "protocol",
+  "provider",
+  "registry",
 ]
 
 arbitrary = [

--- a/crates/maili/Cargo.toml
+++ b/crates/maili/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "maili"
+description = "Connect applications to the OP Stack"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true
+
+[dependencies]
+# Workspace
+maili-protocol = { workspace = true, optional = true }
+maili-provider = { workspace = true, optional = true }
+maili-registry = { workspace = true, optional = true }
+
+[features]
+default = ["std", "serde"]
+
+std = [
+  "maili-protocol?/std",
+  "maili-registry?/std",
+]
+
+full = [
+  "maili-protocol",
+  "maili-provider",
+  "maili-registry",
+]
+
+arbitrary = [
+  "maili-protocol?/arbitrary",
+]
+
+serde = [
+  "maili-protocol?/serde",
+]
+
+# `no_std` support
+registry = ["dep:maili-registry"]
+protocol = ["dep:maili-protocol"]
+
+# std features
+provider = ["dep:maili-provider"]

--- a/crates/maili/Cargo.toml
+++ b/crates/maili/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 maili-protocol = { workspace = true, optional = true }
 maili-provider = { workspace = true, optional = true }
 maili-registry = { workspace = true, optional = true }
+maili-rpc-types-engine = { workspace = true, optional = true }
 
 [features]
 default = ["std", "serde"]
@@ -29,6 +30,7 @@ default = ["std", "serde"]
 std = [
   "maili-protocol?/std",
   "maili-registry?/std",
+  "maili-rpc-types-engine?/std",
 ]
 
 full = [
@@ -43,11 +45,13 @@ arbitrary = [
 
 serde = [
   "maili-protocol?/serde",
+  "maili-rpc-types-engine?/serde",
 ]
 
 # `no_std` support
 registry = ["dep:maili-registry"]
 protocol = ["dep:maili-protocol"]
+rpc-types-engine = ["dep:maili-rpc-types-engine"]
 
 # std features
 provider = ["dep:maili-provider"]

--- a/crates/maili/README.md
+++ b/crates/maili/README.md
@@ -1,0 +1,85 @@
+## `maili`
+
+<a href="https://github.com/op-rs/maili/actions/workflows/ci.yml"><img src="https://github.com/op-rs/maili/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://crates.io/crates/maili"><img src="https://img.shields.io/crates/v/maili.svg" alt="op-alloy crate"></a>
+<a href="https://github.com/op-rs/maili/blob/main/LICENSE-APACHE"><img src="https://img.shields.io/badge/License-APACHE-d1d1f6.svg?label=license&labelColor=2a2f35" alt="License"></a>
+<a href="https://github.com/op-rs/maili/blob/main/LICENSE-MIT"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="License"></a>
+<a href="https://op-rs.github.io/maili"><img src="https://img.shields.io/badge/Book-854a15?logo=mdBook&labelColor=2a2f35" alt="Book"></a>
+
+
+Built on [Alloy][alloy], `maili` connects applications to the OP Stack.
+
+
+### Usage
+
+To use `maili`, add the crate as a dependency to a `Cargo.toml`.
+
+```toml
+maili = "0.6"
+```
+
+### Development Status
+
+`maili` is currently in active development, and is not yet ready for use in production.
+
+
+### Supported Rust Versions (MSRV)
+
+The current MSRV (minimum supported rust version) is 1.81.
+
+Unlike Alloy, maili may use the latest stable release,
+to benefit from the latest features.
+
+The MSRV is not increased automatically, and will be updated
+only as part of a patch (pre-1.0) or minor (post-1.0) release.
+
+
+### Contributing
+
+Maili is built by open source contributors like you, thank you for improving the project!
+
+A [contributing guide][contributing] is available that sets guidelines for contributing.
+
+Pull requests will not be merged unless CI passes, so please ensure that your contribution follows the
+linting rules and passes clippy.
+
+
+### `no_std`
+
+Maili is intended to be `no_std` compatible, initially for use in [kona][kona].
+
+The following crates support `no_std`.
+Notice, provider crates do not support `no_std` compatibility.
+
+- [`maili-protocol`][maili-protocol]
+
+If you would like to add no_std support to a crate,
+please make sure to update [scripts/check_no_std.sh][check-no-std].
+
+
+### Credits
+
+Maili is inspired by the work of several teams and projects, most notably [the Alloy project][alloy].
+
+This would not be possible without the hard work from open source contributors. Thank you.
+
+
+### License
+
+Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
+2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in these crates by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.
+
+
+<!-- Hyperlinks -->
+
+[check-no-std]: https://github.com/op-rs/maili/blob/main/scripts/check_no_std.sh
+
+[kona]: https://github.com/anton-rs/kona
+[alloy]: https://github.com/alloy-rs/alloy
+[contributing]: https://op-rs.github.io/maili
+
+[maili-protocol]: https://crates.io/crates/maili-protocol

--- a/crates/maili/src/lib.rs
+++ b/crates/maili/src/lib.rs
@@ -1,0 +1,20 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/op-rs/maili/main/assets/square.png",
+    html_favicon_url = "https://raw.githubusercontent.com/op-rs/maili/main/assets/favicon.ico"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(any(feature = "full", feature = "std")), no_std)]
+
+#[cfg(feature = "protocol")]
+#[doc(inline)]
+pub use maili_protocol as protocol;
+
+#[cfg(feature = "registry")]
+#[doc(inline)]
+pub use maili_registry as registry;
+
+#[cfg(feature = "provider")]
+#[doc(inline)]
+pub use maili_provider as provider;

--- a/crates/maili/src/lib.rs
+++ b/crates/maili/src/lib.rs
@@ -18,3 +18,7 @@ pub use maili_registry as registry;
 #[cfg(feature = "provider")]
 #[doc(inline)]
 pub use maili_provider as provider;
+
+#[cfg(feature = "rpc-types-engine")]
+#[doc(inline)]
+pub use maili_rpc_types_engine as rpc_types_engine;


### PR DESCRIPTION
### Description

Adds the `Maili` crate which re-exports all `maili-*` crates in the workspace.