### PR TITLE
feat(protocol): Operator Fee

### DIFF
--- a/crates/genesis/src/genesis.rs
+++ b/crates/genesis/src/genesis.rs
@@ -60,6 +60,8 @@ mod tests {
                 blob_base_fee_scalar: None,
                 eip1559_denominator: None,
                 eip1559_elasticity: None,
+                operator_fee_scalar: None,
+                operator_fee_constant: None,
             }),
         }
     }

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -33,8 +33,9 @@ pub use addresses::AddressList;
 mod system;
 pub use system::{
     BatcherUpdateError, EIP1559UpdateError, GasConfigUpdateError, GasLimitUpdateError,
-    LogProcessingError, SystemAccounts, SystemConfig, SystemConfigUpdateError,
-    SystemConfigUpdateType, CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC,
+    LogProcessingError, OperatorFeeUpdateError, SystemAccounts, SystemConfig,
+    SystemConfigUpdateError, SystemConfigUpdateType, CONFIG_UPDATE_EVENT_VERSION_0,
+    CONFIG_UPDATE_TOPIC,
 };
 
 mod chain;

--- a/crates/genesis/src/rollup.rs
+++ b/crates/genesis/src/rollup.rs
@@ -600,6 +600,8 @@ mod tests {
                     blob_base_fee_scalar: None,
                     eip1559_denominator: None,
                     eip1559_elasticity: None,
+                    operator_fee_scalar: None,
+                    operator_fee_constant: None,
                 })
             }
         );

--- a/crates/protocol/src/info/errors.rs
+++ b/crates/protocol/src/info/errors.rs
@@ -17,6 +17,12 @@ pub enum BlockInfoError {
     /// Failed to parse the EIP-1559 elasticity parameter.
     #[error("Failed to parse the EIP-1559 elasticity parameter")]
     Eip1559Elasticity,
+    /// Failed to parse the Operator Fee Scalar.
+    #[error("Failed to parse the Operator fee scalar parameter")]
+    OperatorFeeScalar,
+    /// Failed to parse the Operator Fee Constant.
+    #[error("Failed to parse the Operator fee constant parameter")]
+    OperatorFeeConstant,
 }
 
 /// An error decoding an L1 block info transaction.

--- a/crates/protocol/src/info/isthmus.rs
+++ b/crates/protocol/src/info/isthmus.rs
@@ -1,0 +1,136 @@
+//! Isthmus L1 Block Info transaction types.
+use alloc::{format, string::ToString, vec::Vec};
+use alloy_primitives::{Address, Bytes, B256, U256};
+
+use crate::DecodeError;
+
+/// Represents the fields within an Isthnus L1 block info transaction.
+///
+/// Isthmus Binary Format
+/// +---------+--------------------------+
+/// | Bytes   | Field                    |
+/// +---------+--------------------------+
+/// | 4       | Function signature       |
+/// | 4       | BaseFeeScalar            |
+/// | 4       | BlobBaseFeeScalar        |
+/// | 8       | SequenceNumber           |
+/// | 8       | Timestamp                |
+/// | 8       | L1BlockNumber            |
+/// | 32      | BaseFee                  |
+/// | 32      | BlobBaseFee              |
+/// | 32      | BlockHash                |
+/// | 32      | BatcherHash              |
+/// | 4       | OperatorFeeScalar        |
+/// | 8       | OperatorFeeConstant      |
+/// +---------+--------------------------+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Default, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct L1BlockInfoIsthmus {
+    /// The current L1 origin block number
+    pub number: u64,
+    /// The current L1 origin block's timestamp
+    pub time: u64,
+    /// The current L1 origin block's basefee
+    pub base_fee: u64,
+    /// The current L1 origin block's hash
+    pub block_hash: B256,
+    /// The current sequence number
+    pub sequence_number: u64,
+    /// The address of the batch submitter
+    pub batcher_address: Address,
+    /// The current blob base fee on L1
+    pub blob_base_fee: u128,
+    /// The fee scalar for L1 blobspace data
+    pub blob_base_fee_scalar: u32,
+    /// The fee scalar for L1 data
+    pub base_fee_scalar: u32,
+    /// The operator fee scalar
+    pub operator_fee_scalar: u32,
+    /// The operator fee constant
+    pub operator_fee_constant: u64,
+}
+
+impl L1BlockInfoIsthmus {
+    /// The type byte identifier for the L1 scalar format in Isthmus.
+    pub const L1_SCALAR: u8 = 2;
+
+    /// The length of an L1 info transaction in Isthmus.
+    pub const L1_INFO_TX_LEN: usize = 4 + 32 * 5 + 4 + 8;
+
+    /// The 4 byte selector of "setL1BlockValuesIsthmus()"
+    pub const L1_INFO_TX_SELECTOR: [u8; 4] = [0x09, 0x89, 0x99, 0xbe];
+
+    /// Encodes the [L1BlockInfoIsthmus] object into Ethereum transaction calldata.
+    pub fn encode_calldata(&self) -> Bytes {
+        let mut buf = Vec::with_capacity(Self::L1_INFO_TX_LEN);
+        buf.extend_from_slice(Self::L1_INFO_TX_SELECTOR.as_ref());
+        buf.extend_from_slice(self.base_fee_scalar.to_be_bytes().as_ref());
+        buf.extend_from_slice(self.blob_base_fee_scalar.to_be_bytes().as_ref());
+        buf.extend_from_slice(self.sequence_number.to_be_bytes().as_ref());
+        buf.extend_from_slice(self.time.to_be_bytes().as_ref());
+        buf.extend_from_slice(self.number.to_be_bytes().as_ref());
+        buf.extend_from_slice(U256::from(self.base_fee).to_be_bytes::<32>().as_ref());
+        buf.extend_from_slice(U256::from(self.blob_base_fee).to_be_bytes::<32>().as_ref());
+        buf.extend_from_slice(self.block_hash.as_ref());
+        buf.extend_from_slice(self.batcher_address.into_word().as_ref());
+        buf.extend_from_slice(self.operator_fee_scalar.to_be_bytes().as_ref());
+        buf.extend_from_slice(self.operator_fee_constant.to_be_bytes().as_ref());
+        buf.into()
+    }
+
+    /// Decodes the [L1BlockInfoIsthmus] object from ethereum transaction calldata.
+    pub fn decode_calldata(r: &[u8]) -> Result<Self, DecodeError> {
+        if r.len() != Self::L1_INFO_TX_LEN {
+            return Err(DecodeError::InvalidLength(format!(
+                "Invalid calldata length for Isthmus L1 info transaction, expected {}, got {}",
+                Self::L1_INFO_TX_LEN,
+                r.len()
+            )));
+        }
+        let base_fee_scalar = u32::from_be_bytes(r[4..8].try_into().map_err(|_| {
+            DecodeError::ParseError("Conversion error for base fee scalar".to_string())
+        })?);
+        let blob_base_fee_scalar = u32::from_be_bytes(r[8..12].try_into().map_err(|_| {
+            DecodeError::ParseError("Conversion error for blob base fee scalar".to_string())
+        })?);
+        let sequence_number = u64::from_be_bytes(r[12..20].try_into().map_err(|_| {
+            DecodeError::ParseError("Conversion error for sequence number".to_string())
+        })?);
+        let time =
+            u64::from_be_bytes(r[20..28].try_into().map_err(|_| {
+                DecodeError::ParseError("Conversion error for timestamp".to_string())
+            })?);
+        let number = u64::from_be_bytes(r[28..36].try_into().map_err(|_| {
+            DecodeError::ParseError("Conversion error for L1 block number".to_string())
+        })?);
+        let base_fee =
+            u64::from_be_bytes(r[60..68].try_into().map_err(|_| {
+                DecodeError::ParseError("Conversion error for base fee".to_string())
+            })?);
+        let blob_base_fee = u128::from_be_bytes(r[84..100].try_into().map_err(|_| {
+            DecodeError::ParseError("Conversion error for blob base fee".to_string())
+        })?);
+        let block_hash = B256::from_slice(r[100..132].as_ref());
+        let batcher_address = Address::from_slice(r[144..164].as_ref());
+        let operator_fee_scalar = u32::from_be_bytes(r[164..168].try_into().map_err(|_| {
+            DecodeError::ParseError("Conversion error for operator fee scalar".to_string())
+        })?);
+        let operator_fee_constant = u64::from_be_bytes(r[168..176].try_into().map_err(|_| {
+            DecodeError::ParseError("Conversion error for operator fee constant".to_string())
+        })?);
+
+        Ok(Self {
+            number,
+            time,
+            base_fee,
+            block_hash,
+            sequence_number,
+            batcher_address,
+            blob_base_fee,
+            blob_base_fee_scalar,
+            base_fee_scalar,
+            operator_fee_scalar,
+            operator_fee_constant,
+        })
+    }
+}

--- a/crates/protocol/src/info/mod.rs
+++ b/crates/protocol/src/info/mod.rs
@@ -3,6 +3,9 @@
 mod variant;
 pub use variant::L1BlockInfoTx;
 
+mod isthmus;
+pub use isthmus::L1BlockInfoIsthmus;
+
 mod bedrock;
 pub use bedrock::L1BlockInfoBedrock;
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -66,7 +66,7 @@ pub use deposits::{
 mod info;
 pub use info::{
     closing_deposit_context_tx, BlockInfoError, DecodeError, L1BlockInfoBedrock,
-    L1BlockInfoEcotone, L1BlockInfoInterop, L1BlockInfoTx,
+    L1BlockInfoEcotone, L1BlockInfoInterop, L1BlockInfoIsthmus, L1BlockInfoTx,
 };
 
 mod fee;

--- a/crates/protocol/src/utils.rs
+++ b/crates/protocol/src/utils.rs
@@ -8,7 +8,7 @@ use maili_genesis::{RollupConfig, SystemConfig};
 use op_alloy_consensus::OpBlock;
 
 use crate::{
-    info::L1BlockInfoInterop, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx,
+    L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoInterop, L1BlockInfoIsthmus, L1BlockInfoTx,
     OpBlockConversionError, SpanBatchError, SpanDecodingError,
 };
 
@@ -54,6 +54,11 @@ pub fn to_system_config(
             ..
         })
         | L1BlockInfoTx::Interop(L1BlockInfoInterop {
+            base_fee_scalar,
+            blob_base_fee_scalar,
+            ..
+        })
+        | L1BlockInfoTx::Isthmus(L1BlockInfoIsthmus {
             base_fee_scalar,
             blob_base_fee_scalar,
             ..

--- a/crates/registry/etc/configs.json
+++ b/crates/registry/etc/configs.json
@@ -62,7 +62,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -142,7 +144,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -222,7 +226,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -302,7 +308,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -382,7 +390,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -462,7 +472,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -542,7 +554,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -622,7 +636,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -702,7 +718,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -786,7 +804,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -866,7 +886,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -946,7 +968,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1026,7 +1050,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1106,7 +1132,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1186,7 +1214,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1266,7 +1296,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1346,7 +1378,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1430,7 +1464,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1510,7 +1546,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1590,7 +1628,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1670,7 +1710,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1754,7 +1796,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1834,7 +1878,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1914,7 +1960,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -1994,7 +2042,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2078,7 +2128,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2162,7 +2214,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2242,7 +2296,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2338,7 +2394,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2418,7 +2476,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2498,7 +2558,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2578,7 +2640,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2658,7 +2722,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2738,7 +2804,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2818,7 +2886,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2898,7 +2968,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -2978,7 +3050,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3058,7 +3132,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3138,7 +3214,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3218,7 +3296,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3298,7 +3378,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3378,7 +3460,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3458,7 +3542,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3542,7 +3628,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3622,7 +3710,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3702,7 +3792,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3782,7 +3874,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3878,7 +3972,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {
@@ -3958,7 +4054,9 @@
               "baseFeeScalar": null,
               "blobBaseFeeScalar": null,
               "eip1559Denominator": null,
-              "eip1559Elasticity": null
+              "eip1559Elasticity": null,
+              "operatorFeeScalar": null,
+              "operatorFeeConstant": null
             }
           },
           "Addresses": {

--- a/crates/registry/src/test_utils/base_mainnet.rs
+++ b/crates/registry/src/test_utils/base_mainnet.rs
@@ -28,6 +28,8 @@ pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
             blob_base_fee_scalar: None,
             eip1559_denominator: None,
             eip1559_elasticity: None,
+            operator_fee_scalar: None,
+            operator_fee_constant: None,
         }),
     },
     block_time: 2,

--- a/crates/registry/src/test_utils/base_sepolia.rs
+++ b/crates/registry/src/test_utils/base_sepolia.rs
@@ -28,6 +28,8 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
             blob_base_fee_scalar: None,
             eip1559_denominator: None,
             eip1559_elasticity: None,
+            operator_fee_scalar: None,
+            operator_fee_constant: None,
         }),
     },
     block_time: 2,

--- a/crates/registry/src/test_utils/op_mainnet.rs
+++ b/crates/registry/src/test_utils/op_mainnet.rs
@@ -28,6 +28,8 @@ pub const OP_MAINNET_CONFIG: RollupConfig = RollupConfig {
             blob_base_fee_scalar: None,
             eip1559_denominator: None,
             eip1559_elasticity: None,
+            operator_fee_scalar: None,
+            operator_fee_constant: None,
         }),
     },
     block_time: 2_u64,

--- a/crates/registry/src/test_utils/op_sepolia.rs
+++ b/crates/registry/src/test_utils/op_sepolia.rs
@@ -28,6 +28,8 @@ pub const OP_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
             blob_base_fee_scalar: None,
             eip1559_denominator: None,
             eip1559_elasticity: None,
+            operator_fee_scalar: None,
+            operator_fee_constant: None,
         }),
     },
     block_time: 2,


### PR DESCRIPTION
### Description

Defines `L1BlockInfoIsthmus` in maili-protocol to include the new operator fee scalar and operator fee constant.

Original PR in `op-alloy`: https://github.com/alloy-rs/op-alloy/pull/130

### Additional Context

[Design Doc](https://github.com/ethereum-optimism/design-docs/pull/81)
[Spec](https://github.com/ethereum-optimism/specs/pull/382/files).