### PR TITLE
fix(protocol): Channel ID Randomization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ tracing = { version = "0.1.41", default-features = false }
 ## misc-testing
 arbitrary = { version = "1.4.1", features = ["derive"] }
 arbtest = "0.3.2"
-rand = "0.8.5"
+rand = { version = "0.8.5", default-features = false }
 proptest = "1.6.0"
 proptest-derive = "0.5.1"
 tokio = "1.43.0"

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -27,7 +27,7 @@ alloy-eips.workspace = true
 alloy-consensus.workspace = true
 
 # Misc
-rand = { workspace = true, features = ["getrandom"] }
+rand = { workspace = true, features = ["small_rng"] }
 derive_more = { workspace = true, default-features = false, features = ["from", "as_ref"] }
 tracing.workspace = true
 thiserror.workspace = true

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -27,6 +27,7 @@ alloy-eips.workspace = true
 alloy-consensus.workspace = true
 
 # Misc
+rand = { workspace = true, features = ["getrandom"] }
 derive_more = { workspace = true, default-features = false, features = ["from", "as_ref"] }
 tracing.workspace = true
 thiserror.workspace = true

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -27,7 +27,6 @@ alloy-eips.workspace = true
 alloy-consensus.workspace = true
 
 # Misc
-rand = { workspace = true, features = ["getrandom"] }
 derive_more = { workspace = true, default-features = false, features = ["from", "as_ref"] }
 tracing.workspace = true
 thiserror.workspace = true
@@ -45,6 +44,9 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 # `serde` feature
 serde = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
+
+# `std` feature
+rand = { workspace = true, features = ["getrandom"], optional = true }
 
 # `test-utils` feature
 spin = { workspace = true, optional = true }
@@ -78,5 +80,5 @@ arbitrary = [
   "alloy-primitives/rand",
   "alloy-primitives/arbitrary",
 ]
-std = ["op-alloy-consensus/std", "op-alloy-genesis/std", "brotli/std"]
+std = ["dep:rand", "op-alloy-consensus/std", "op-alloy-genesis/std", "brotli/std"]
 serde = ["dep:serde", "dep:alloy-serde", "op-alloy-consensus/serde", "op-alloy-genesis/serde"]

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -27,6 +27,7 @@ alloy-eips.workspace = true
 alloy-consensus.workspace = true
 
 # Misc
+rand = { workspace = true, features = ["getrandom"] }
 derive_more = { workspace = true, default-features = false, features = ["from", "as_ref"] }
 tracing.workspace = true
 thiserror.workspace = true
@@ -44,9 +45,6 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 # `serde` feature
 serde = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
-
-# `std` feature
-rand = { workspace = true, features = ["getrandom"], optional = true }
 
 # `test-utils` feature
 spin = { workspace = true, optional = true }
@@ -80,5 +78,5 @@ arbitrary = [
   "alloy-primitives/rand",
   "alloy-primitives/arbitrary",
 ]
-std = ["dep:rand", "op-alloy-consensus/std", "op-alloy-genesis/std", "brotli/std"]
+std = ["op-alloy-consensus/std", "op-alloy-genesis/std", "brotli/std"]
 serde = ["dep:serde", "dep:alloy-serde", "op-alloy-consensus/serde", "op-alloy-genesis/serde"]

--- a/crates/protocol/src/channel_out.rs
+++ b/crates/protocol/src/channel_out.rs
@@ -202,8 +202,9 @@ mod tests {
         channel.reset();
         assert_eq!(channel.rlp_length, 0);
         assert_eq!(channel.frame_number, 0);
-        // The odds of this flaking are so astronomically low
-        // the randomized [u8; 16] is about 1/255^16
+        // The odds of a randomized channel id being equal to the
+        // default are so astronomically low, this test will always pass.
+        // The randomized [u8; 16] is about 1/255^16.
         assert!(channel.id != ChannelId::default());
         assert!(!channel.closed);
     }


### PR DESCRIPTION
### Description

Fixes `ChannelOut` to correctly randomize the `ChannelId` on reset using the [operating system's randomness](https://docs.rs/rand/latest/rand/rngs/struct.OsRng.html).