### PR TITLE
chore(deps): bump op-alloy to 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ maili-registry = { version = "0.1.0", path = "crates/registry", default-features
 maili-rpc-types-engine = { version = "0.1.0", path = "crates/rpc-types-engine", default-features = false }
 
 # OP-Alloy
-op-alloy-genesis = { version = "0.9.1", default-features = false }
-op-alloy-consensus = { version = "0.9.1", default-features = false }
-op-alloy-network = { version = "0.9.1", default-features = false }
-op-alloy-rpc-types = { version = "0.9.1", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.9.1", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.9.1", default-features = false }
+op-alloy-genesis = { version = "0.9.2", default-features = false }
+op-alloy-consensus = { version = "0.9.2", default-features = false }
+op-alloy-network = { version = "0.9.2", default-features = false }
+op-alloy-rpc-types = { version = "0.9.2", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.9.2", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.9.2", default-features = false }
 
 # Alloy
 alloy-eips = { version = "0.9.2", default-features = false }


### PR DESCRIPTION
Bumps `op-alloy` to 0.9.2
