### PR TITLE
perf(rpc): Smol perf improvement `SupervisorApi`, pass slice instead of vec as param

### DIFF
--- a/crates/rpc-jsonrpsee/src/traits.rs
+++ b/crates/rpc-jsonrpsee/src/traits.rs
@@ -156,7 +156,7 @@ pub trait SupervisorApi {
     #[method(name = "checkMessages")]
     async fn check_messages(
         &self,
-        messages: Vec<ExecutingMessage>,
+        messages: &[ExecutingMessage],
         min_safety: SafetyLevel,
     ) -> RpcResult<()>;
 }


### PR DESCRIPTION
Passes a slice of `EngineMessages` instead of a vector in `SupervisorApi::check_messages`