### PR TITLE
fix: Add Crates to no_std Checks

### DIFF
--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -2,7 +2,10 @@
 set -eo pipefail
 
 no_std_packages=(
+  maili
   maili-protocol
+  maili-registry
+  maili-rpc-types-engine
 )
 
 for package in "${no_std_packages[@]}"; do

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -3,9 +3,9 @@ set -eo pipefail
 
 no_std_packages=(
   maili
+  maili-common
   maili-protocol
   maili-registry
-  maili-rpc-types-engine
 )
 
 for package in "${no_std_packages[@]}"; do


### PR DESCRIPTION
### Description

Add `no_std` maili crates to `no_std` check script.