### PR TITLE
fix(maili): Missing Crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
 # Workspace
+maili-common = { version = "0.1.1", path = "crates/common", default-features = false }
 maili-protocol = { version = "0.1.1", path = "crates/protocol", default-features = false }
 maili-provider = { version = "0.1.1", path = "crates/provider", default-features = false }
 maili-registry = { version = "0.1.1", path = "crates/registry", default-features = false }
-maili-common = { version = "0.1.1", path = "crates/common", default-features = false }
+maili-rpc-jsonrpsee = { version = "0.1.1", path = "crates/rpc-jsonrpsee", default-features = false }
 
 # OP-Alloy
 op-alloy-genesis = { version = "0.9.2", default-features = false }

--- a/crates/common/README.md
+++ b/crates/common/README.md
@@ -1,4 +1,4 @@
-## `maili-common
+## `maili-common`
 
 <a href="https://github.com/op-rs/maili/actions/workflows/ci.yml"><img src="https://github.com/op-rs/maili/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
 <a href="https://crates.io/crates/maili-common"><img src="https://img.shields.io/crates/v/maili-common.svg" alt="maili-common crate"></a>

--- a/crates/maili/Cargo.toml
+++ b/crates/maili/Cargo.toml
@@ -19,10 +19,11 @@ workspace = true
 
 [dependencies]
 # Workspace
+maili-common = { workspace = true, optional = true }
 maili-protocol = { workspace = true, optional = true }
 maili-provider = { workspace = true, optional = true }
 maili-registry = { workspace = true, optional = true }
-maili-common = { workspace = true, optional = true }
+maili-rpc-jsonrpsee = { workspace = true, optional = true }
 
 [features]
 default = ["std", "serde"]
@@ -34,9 +35,11 @@ std = [
 ]
 
 full = [
+  "common",
   "protocol",
   "provider",
   "registry",
+  "rpc-jsonrpsee",
 ]
 
 arbitrary = [
@@ -55,3 +58,4 @@ common = ["dep:maili-common"]
 
 # std features
 provider = ["dep:maili-provider"]
+rpc-jsonrpsee = ["dep:maili-rpc-jsonrpsee"]

--- a/crates/maili/README.md
+++ b/crates/maili/README.md
@@ -15,7 +15,7 @@ Built on [Alloy][alloy], `maili` connects applications to the OP Stack.
 To use `maili`, add the crate as a dependency to a `Cargo.toml`.
 
 ```toml
-maili = "0.6"
+maili = "0.1"
 ```
 
 ### Development Status
@@ -27,8 +27,7 @@ maili = "0.6"
 
 The current MSRV (minimum supported rust version) is 1.81.
 
-Unlike Alloy, maili may use the latest stable release,
-to benefit from the latest features.
+Maili may use the latest stable release, to benefit from the latest features.
 
 The MSRV is not increased automatically, and will be updated
 only as part of a patch (pre-1.0) or minor (post-1.0) release.
@@ -52,6 +51,8 @@ The following crates support `no_std`.
 Notice, provider crates do not support `no_std` compatibility.
 
 - [`maili-protocol`][maili-protocol]
+- [`maili-registry`][maili-registry]
+- [`maili-rpc-types-engine`][maili-rpc-types-engine]
 
 If you would like to add no_std support to a crate,
 please make sure to update [scripts/check_no_std.sh][check-no-std].
@@ -83,3 +84,5 @@ shall be dual licensed as above, without any additional terms or conditions.
 [contributing]: https://op-rs.github.io/maili
 
 [maili-protocol]: https://crates.io/crates/maili-protocol
+[maili-registry]: https://crates.io/crates/maili-registry
+[maili-rpc-types-engine]: https://crates.io/crates/maili-rpc-types-engine

--- a/crates/maili/src/lib.rs
+++ b/crates/maili/src/lib.rs
@@ -19,6 +19,10 @@ pub use maili_registry as registry;
 #[doc(inline)]
 pub use maili_provider as provider;
 
+#[cfg(feature = "rpc-jsonrpsee")]
+#[doc(inline)]
+pub use maili_rpc_jsonrpsee as rpc_jsonrpsee;
+
 #[cfg(feature = "common")]
 #[doc(inline)]
 pub use maili_common as common;


### PR DESCRIPTION
### Description

Fixes up the `maili` crate to include `maili-rpc-jsonrpsee` and some feature fixes.