### PR TITLE
chore(common): Migrate deposit source types from `op-alloy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 maili-protocol = { version = "0.1.1", path = "crates/protocol", default-features = false }
 maili-provider = { version = "0.1.1", path = "crates/provider", default-features = false }
 maili-registry = { version = "0.1.1", path = "crates/registry", default-features = false }
-maili-rpc-types-engine = { version = "0.1.1", path = "crates/rpc-types-engine", default-features = false }
+maili-common = { version = "0.1.1", path = "crates/common", default-features = false }
 
 # OP-Alloy
 op-alloy-genesis = { version = "0.9.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following crates are provided by `maili`.
 - ![maili-protocol](https://img.shields.io/crates/v/maili-protocol?label=maili-protocol)
 - ![maili-registry](https://img.shields.io/crates/v/maili-registry?label=maili-registry)
 - ![maili-provider](https://img.shields.io/crates/v/maili-provider?label=maili-provider)
-- ![maili-rpc-types-engine](https://img.shields.io/crates/v/maili-rpc-types-engine?label=maili-rpc-types-engine)
+- ![maili-common](https://img.shields.io/crates/v/maili-common?label=maili-common)
 
 
 ## Development Status
@@ -55,7 +55,7 @@ Notice, provider crates do not support `no_std` compatibility.
 - [`maili-protocol`][maili-protocol]
 - [`maili-provider`][maili-provider]
 - [`maili-registry`][maili-registry] (note: requires `serde`)
-- [`maili-rpc-types-engine`][maili-rpc-types-engine]
+- [`maili-common`][maili-common]
 
 If you would like to add no_std support to a crate,
 please make sure to update [scripts/check_no_std.sh][check-no-std].
@@ -89,4 +89,4 @@ shall be dual licensed as above, without any additional terms or conditions.
 [maili-protocol]: https://crates.io/crates/maili-protocol
 [maili-provider]: https://crates.io/crates/maili-provider
 [maili-registry]: https://crates.io/crates/maili-registry
-[maili-rpc-types-engine]: https://crates.io/crates/maili-rpc-types-engine
+[maili-common]: https://crates.io/crates/maili-common

--- a/book/src/links.md
+++ b/book/src/links.md
@@ -8,7 +8,7 @@
 [maili-protocol]: https://crates.io/crates/maili-protocol
 [maili-provider]: https://crates.io/crates/maili-provider
 [maili-registry]: https://crates.io/crates/maili-registry
-[maili-rpc-types-engine]: https://crates.io/crates/maili-rpc-types-engine
+[maili-common]: https://crates.io/crates/maili-common
 
 <!-- maili-protocol -->
 

--- a/book/src/starting.md
+++ b/book/src/starting.md
@@ -57,14 +57,14 @@ so `maili-protocol` types can be used from `maili` through `maili::protocol::Ins
 
 - [`maili-protocol`][maili-protocol] (supports `no_std`)
 - [`maili-provider`][maili-provider]
-- [`maili-rpc-types-engine`][maili-rpc-types-engine] (supports `no_std`)
+- [`maili-common`][maili-common] (supports `no_std`)
 
 ## `no_std`
 
 As noted above, the following crates are `no_std` compatible.
 
 - [`maili-protocol`][maili-protocol]
-- [`maili-rpc-types-engine`][maili-rpc-types-engine]
+- [`maili-common`][maili-common]
 
 To add `no_std` support to a crate, ensure the [check_no_std][check-no-std]
 script is updated to include this crate once `no_std` compatible.

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "maili-rpc-types-engine"
-description = "Optimism RPC types for the `engine` namespace"
+name = "maili-common"
+description = "Optimism common types"
 
 version.workspace = true
 edition.workspace = true

--- a/crates/common/README.md
+++ b/crates/common/README.md
@@ -1,10 +1,10 @@
-## `maili-rpc-types-engine`
+## `maili-common
 
 <a href="https://github.com/op-rs/maili/actions/workflows/ci.yml"><img src="https://github.com/op-rs/maili/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
-<a href="https://crates.io/crates/maili-rpc-types-engine"><img src="https://img.shields.io/crates/v/maili-rpc-types-engine.svg" alt="maili-rpc-types-engine crate"></a>
+<a href="https://crates.io/crates/maili-common"><img src="https://img.shields.io/crates/v/maili-common.svg" alt="maili-common crate"></a>
 <a href="https://github.com/op-rs/maili/blob/main/LICENSE-MIT"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
 <a href="https://github.com/op-rs/maili/blob/main/LICENSE-APACHE"><img src="https://img.shields.io/badge/License-APACHE-d1d1f6.svg?label=license&labelColor=2a2f35" alt="Apache License"></a>
 <a href="https://op-rs.github.io/maili"><img src="https://img.shields.io/badge/Book-854a15?logo=mdBook&labelColor=2a2f35" alt="Book"></a>
 
 
-Optimism RPC types for the `engine` namespace.
+Optimism common types

--- a/crates/common/src/deposit_source.rs
+++ b/crates/common/src/deposit_source.rs
@@ -1,0 +1,128 @@
+//! Classification of deposit transaction source
+
+use alloc::string::String;
+use alloy_primitives::{keccak256, B256};
+
+/// Source domain identifiers for deposit transactions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum DepositSourceDomainIdentifier {
+    /// A user deposit source.
+    User = 0,
+    /// A L1 info deposit source.
+    L1Info = 1,
+    /// An upgrade deposit source.
+    Upgrade = 2,
+}
+
+/// Source domains for deposit transactions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DepositSourceDomain {
+    /// A user deposit source.
+    User(UserDepositSource),
+    /// A L1 info deposit source.
+    L1Info(L1InfoDepositSource),
+    /// An upgrade deposit source.
+    Upgrade(UpgradeDepositSource),
+}
+
+impl DepositSourceDomain {
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        match self {
+            Self::User(ds) => ds.source_hash(),
+            Self::L1Info(ds) => ds.source_hash(),
+            Self::Upgrade(ds) => ds.source_hash(),
+        }
+    }
+}
+
+/// A L1 info deposit transaction source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct L1InfoDepositSource {
+    /// The L1 block hash.
+    pub l1_block_hash: B256,
+    /// The sequence number.
+    pub seq_number: u64,
+}
+
+impl L1InfoDepositSource {
+    /// Creates a new [L1InfoDepositSource].
+    pub const fn new(l1_block_hash: B256, seq_number: u64) -> Self {
+        Self { l1_block_hash, seq_number }
+    }
+
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        let mut input = [0u8; 32 * 2];
+        input[..32].copy_from_slice(&self.l1_block_hash[..]);
+        input[32 * 2 - 8..].copy_from_slice(&self.seq_number.to_be_bytes());
+        let deposit_id_hash = keccak256(input);
+        let mut domain_input = [0u8; 32 * 2];
+        let identifier_bytes: [u8; 8] =
+            (DepositSourceDomainIdentifier::L1Info as u64).to_be_bytes();
+        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
+        domain_input[32..].copy_from_slice(&deposit_id_hash[..]);
+        keccak256(domain_input)
+    }
+}
+
+/// A deposit transaction source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UserDepositSource {
+    /// The L1 block hash.
+    pub l1_block_hash: B256,
+    /// The log index.
+    pub log_index: u64,
+}
+
+impl UserDepositSource {
+    /// Creates a new [UserDepositSource].
+    pub const fn new(l1_block_hash: B256, log_index: u64) -> Self {
+        Self { l1_block_hash, log_index }
+    }
+
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        let mut input = [0u8; 32 * 2];
+        input[..32].copy_from_slice(&self.l1_block_hash[..]);
+        input[32 * 2 - 8..].copy_from_slice(&self.log_index.to_be_bytes());
+        let deposit_id_hash = keccak256(input);
+        let mut domain_input = [0u8; 32 * 2];
+        let identifier_bytes: [u8; 8] = (DepositSourceDomainIdentifier::User as u64).to_be_bytes();
+        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
+        domain_input[32..].copy_from_slice(&deposit_id_hash[..]);
+        keccak256(domain_input)
+    }
+}
+
+/// An upgrade deposit transaction source.
+///
+/// This implements the translation of upgrade-tx identity information to a deposit source-hash,
+/// which makes the deposit uniquely identifiable.
+/// System-upgrade transactions have their own domain for source-hashes,
+/// to not conflict with user-deposits or deposited L1 information.
+/// The intent identifies the upgrade-tx uniquely, in a human-readable way.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UpgradeDepositSource {
+    /// The intent.
+    pub intent: String,
+}
+
+impl UpgradeDepositSource {
+    /// Creates a new [UpgradeDepositSource].
+    pub const fn new(intent: String) -> Self {
+        Self { intent }
+    }
+
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        let intent_hash = keccak256(self.intent.as_bytes());
+        let mut domain_input = [0u8; 32 * 2];
+        let identifier_bytes: [u8; 8] =
+            (DepositSourceDomainIdentifier::Upgrade as u64).to_be_bytes();
+        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
+        domain_input[32..].copy_from_slice(&intent_hash[..]);
+        keccak256(domain_input)
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -9,6 +9,12 @@
 
 extern crate alloc;
 
+mod deposit_source;
+pub use deposit_source::{
+    DepositSourceDomain, DepositSourceDomainIdentifier, L1InfoDepositSource, UpgradeDepositSource,
+    UserDepositSource,
+};
+
 mod superchain;
 pub use superchain::{
     ProtocolVersion, ProtocolVersionError, ProtocolVersionFormatV0, SuperchainSignal,

--- a/crates/common/src/superchain.rs
+++ b/crates/common/src/superchain.rs
@@ -1,3 +1,5 @@
+//! Optimism RPC types for the `engine` namespace
+
 use alloc::{
     format,
     string::{String, ToString},

--- a/crates/maili/Cargo.toml
+++ b/crates/maili/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 maili-protocol = { workspace = true, optional = true }
 maili-provider = { workspace = true, optional = true }
 maili-registry = { workspace = true, optional = true }
-maili-rpc-types-engine = { workspace = true, optional = true }
+maili-common = { workspace = true, optional = true }
 
 [features]
 default = ["std", "serde"]
@@ -30,7 +30,7 @@ default = ["std", "serde"]
 std = [
   "maili-protocol?/std",
   "maili-registry?/std",
-  "maili-rpc-types-engine?/std",
+  "maili-common?/std",
 ]
 
 full = [
@@ -45,13 +45,13 @@ arbitrary = [
 
 serde = [
   "maili-protocol?/serde",
-  "maili-rpc-types-engine?/serde",
+  "maili-common?/serde",
 ]
 
 # `no_std` support
 registry = ["dep:maili-registry"]
 protocol = ["dep:maili-protocol"]
-rpc-types-engine = ["dep:maili-rpc-types-engine"]
+rpc-types-engine = ["dep:maili-common"]
 
 # std features
 provider = ["dep:maili-provider"]

--- a/crates/maili/Cargo.toml
+++ b/crates/maili/Cargo.toml
@@ -51,7 +51,7 @@ serde = [
 # `no_std` support
 registry = ["dep:maili-registry"]
 protocol = ["dep:maili-protocol"]
-rpc-types-engine = ["dep:maili-common"]
+common = ["dep:maili-common"]
 
 # std features
 provider = ["dep:maili-provider"]

--- a/crates/maili/src/lib.rs
+++ b/crates/maili/src/lib.rs
@@ -21,4 +21,4 @@ pub use maili_provider as provider;
 
 #[cfg(feature = "rpc-types-engine")]
 #[doc(inline)]
-pub use maili_rpc_types_engine as rpc_types_engine;
+pub use maili_common as rpc_types_engine;

--- a/crates/maili/src/lib.rs
+++ b/crates/maili/src/lib.rs
@@ -19,6 +19,6 @@ pub use maili_registry as registry;
 #[doc(inline)]
 pub use maili_provider as provider;
 
-#[cfg(feature = "rpc-types-engine")]
+#[cfg(feature = "common")]
 #[doc(inline)]
-pub use maili_common as rpc_types_engine;
+pub use maili_common as common;

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 # Workspace
-maili-rpc-types-engine = { workspace = true, features = ["serde"] }
+maili-common = { workspace = true, features = ["serde"] }
 
 # OP-Alloy
 op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }

--- a/crates/provider/src/ext/engine.rs
+++ b/crates/provider/src/ext/engine.rs
@@ -6,7 +6,7 @@ use alloy_rpc_types_engine::{
     ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
 };
 use alloy_transport::{Transport, TransportResult};
-use maili_rpc_types_engine::{ProtocolVersion, SuperchainSignal};
+use maili_common::{ProtocolVersion, SuperchainSignal};
 use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpPayloadAttributes,
 };

--- a/crates/rpc-jsonrpsee/Cargo.toml
+++ b/crates/rpc-jsonrpsee/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 # Workspace
 maili-protocol = { workspace = true, default-features = false, features = ["serde"] }
-maili-rpc-types-engine = { workspace = true, default-features = false, features = ["serde"] }
+maili-common = { workspace = true, default-features = false, features = ["serde"] }
 
 # OP-Alloy
 op-alloy-rpc-types.workspace = true
@@ -34,7 +34,7 @@ getrandom.workspace = true
 default = ["std"]
 std = [
     "maili-protocol/std",
-    "maili-rpc-types-engine/std",
+    "maili-common/std",
     "op-alloy-rpc-types/std",
     "alloy-eips/std",
     "alloy-primitives/std",

--- a/crates/rpc-jsonrpsee/src/traits.rs
+++ b/crates/rpc-jsonrpsee/src/traits.rs
@@ -8,8 +8,8 @@ use core::net::IpAddr;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{B256, U64};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use maili_common::{ProtocolVersion, SuperchainSignal};
 use maili_protocol::{ExecutingMessage, SafetyLevel};
-use maili_rpc_types_engine::{ProtocolVersion, SuperchainSignal};
 use op_alloy_rpc_types::{
     OutputResponse, PeerDump, PeerInfo, PeerStats, RollupConfig, SafeHeadResponse, SyncStatus,
 };


### PR DESCRIPTION
Migrates `op_alloy_consensus::transaction::source` to `maili_common::deposit_source`.