### PR TITLE
feat(protocol): Fjord TX Size Estimation

### DIFF
--- a/crates/protocol/src/info/fjord.rs
+++ b/crates/protocol/src/info/fjord.rs
@@ -1,0 +1,55 @@
+//! Contains methods for the FJORD Hardfork.
+
+use crate::utils::flz_compress_len;
+use alloy_primitives::U256;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L79>
+const L1_COST_FASTLZ_COEF: u64 = 836_500;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L78>
+/// Inverted to be used with `saturating_sub`.
+const L1_COST_INTERCEPT: u64 = 42_585_600;
+
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#82>
+const MIN_TX_SIZE_SCALED: u64 = 100 * 1_000_000;
+
+/// Calculate the estimated compressed transaction size in bytes, scaled by 1e6.
+/// This value is computed based on the following formula:
+/// max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
+pub fn estimate_fjord_tx_size(input: &[u8]) -> U256 {
+    let fastlz_size = flz_compress_len(input) as u64;
+
+    U256::from(
+        fastlz_size
+            .saturating_mul(L1_COST_FASTLZ_COEF)
+            .saturating_sub(L1_COST_INTERCEPT)
+            .max(MIN_TX_SIZE_SCALED),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_empty_tx_size() {
+        let input = vec![];
+        let expected = MIN_TX_SIZE_SCALED;
+        assert_eq!(estimate_fjord_tx_size(&input), U256::from(expected));
+    }
+
+    #[test]
+    fn test_estimate_small_tx_size() {
+        let input = vec![13; 100];
+        let expected = MIN_TX_SIZE_SCALED;
+        assert_eq!(estimate_fjord_tx_size(&input), U256::from(expected));
+    }
+
+    #[test]
+    fn test_estimate_large_tx_size() {
+        let input = vec![13; 1_000_000];
+        let fastlz_size = flz_compress_len(&input) as u64;
+        let expected = fastlz_size * L1_COST_FASTLZ_COEF - L1_COST_INTERCEPT;
+        assert_eq!(estimate_fjord_tx_size(&input), U256::from(expected));
+    }
+}

--- a/crates/protocol/src/info/mod.rs
+++ b/crates/protocol/src/info/mod.rs
@@ -1,5 +1,8 @@
 //! Module containing L1 Attributes types (aka the L1 block info transaction).
 
+mod fjord;
+pub use fjord::estimate_fjord_tx_size;
+
 mod variant;
 pub use variant::L1BlockInfoTx;
 

--- a/crates/protocol/src/info/variant.rs
+++ b/crates/protocol/src/info/variant.rs
@@ -177,6 +177,42 @@ impl L1BlockInfoTx {
         }
     }
 
+    /// Returns the l1 base fee.
+    pub fn l1_base_fee(&self) -> U256 {
+        match self {
+            Self::Bedrock(L1BlockInfoBedrock { base_fee, .. }) => U256::from(*base_fee),
+            Self::Ecotone(L1BlockInfoEcotone { base_fee, .. }) => U256::from(*base_fee),
+        }
+    }
+
+    /// Returns the l1 fee scalar.
+    pub fn l1_fee_scalar(&self) -> U256 {
+        match self {
+            Self::Bedrock(L1BlockInfoBedrock { l1_fee_scalar, .. }) => *l1_fee_scalar,
+            Self::Ecotone(L1BlockInfoEcotone { base_fee_scalar, .. }) => {
+                U256::from(*base_fee_scalar)
+            }
+        }
+    }
+
+    /// Returns the blob base fee.
+    pub fn blob_base_fee(&self) -> U256 {
+        match self {
+            Self::Bedrock(_) => U256::ZERO,
+            Self::Ecotone(L1BlockInfoEcotone { blob_base_fee, .. }) => U256::from(*blob_base_fee),
+        }
+    }
+
+    /// Returns the blob base fee scalar.
+    pub fn blob_base_fee_scalar(&self) -> U256 {
+        match self {
+            Self::Bedrock(_) => U256::ZERO,
+            Self::Ecotone(L1BlockInfoEcotone { blob_base_fee_scalar, .. }) => {
+                U256::from(*blob_base_fee_scalar)
+            }
+        }
+    }
+
     /// Returns the L1 fee overhead for the info transaction. After ecotone, this value is ignored.
     pub const fn l1_fee_overhead(&self) -> U256 {
         match self {
@@ -253,6 +289,54 @@ mod test {
             ecotone.block_hash(),
             b256!("1c4c84c50740386c7dc081efddd644405f04cde73e30a2e381737acce9f5add3")
         );
+    }
+
+    #[test]
+    fn test_l1_base_fee() {
+        let bedrock =
+            L1BlockInfoTx::Bedrock(L1BlockInfoBedrock { base_fee: 123, ..Default::default() });
+        assert_eq!(bedrock.l1_base_fee(), U256::from(123));
+
+        let ecotone =
+            L1BlockInfoTx::Ecotone(L1BlockInfoEcotone { base_fee: 456, ..Default::default() });
+        assert_eq!(ecotone.l1_base_fee(), U256::from(456));
+    }
+
+    #[test]
+    fn test_l1_fee_scalar() {
+        let bedrock = L1BlockInfoTx::Bedrock(L1BlockInfoBedrock {
+            l1_fee_scalar: U256::from(123),
+            ..Default::default()
+        });
+        assert_eq!(bedrock.l1_fee_scalar(), U256::from(123));
+
+        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
+            base_fee_scalar: 456,
+            ..Default::default()
+        });
+        assert_eq!(ecotone.l1_fee_scalar(), U256::from(456));
+    }
+
+    #[test]
+    fn test_blob_base_fee() {
+        let bedrock = L1BlockInfoTx::Bedrock(L1BlockInfoBedrock { ..Default::default() });
+        assert_eq!(bedrock.blob_base_fee(), U256::ZERO);
+
+        let ecotone =
+            L1BlockInfoTx::Ecotone(L1BlockInfoEcotone { blob_base_fee: 456, ..Default::default() });
+        assert_eq!(ecotone.blob_base_fee(), U256::from(456));
+    }
+
+    #[test]
+    fn test_blob_base_fee_scalar() {
+        let bedrock = L1BlockInfoTx::Bedrock(L1BlockInfoBedrock { ..Default::default() });
+        assert_eq!(bedrock.blob_base_fee_scalar(), U256::ZERO);
+
+        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
+            blob_base_fee_scalar: 456,
+            ..Default::default()
+        });
+        assert_eq!(ecotone.blob_base_fee_scalar(), U256::from(456));
     }
 
     #[test]

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -68,7 +68,8 @@ pub use deposits::{
 
 mod info;
 pub use info::{
-    BlockInfoError, DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx,
+    estimate_fjord_tx_size, BlockInfoError, DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone,
+    L1BlockInfoTx,
 };
 
 mod fee;


### PR DESCRIPTION
### Description

Adds a FJORD tx size estimation util method to `maili-protocol`.

This breaks out functionality from #35.