### PR TITLE
chore: Issue Tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: File a bug report
-labels: ["bug"]
+labels: ["C-bug", "S-needs-triage"]
 title: "[Bug] "
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest a feature
-labels: ["enhancement"]
+labels: ["C-feat", "S-needs-triage"]
 title: "[Feature] "
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/op-rs/maili/discussions
+    about: Please ask and answer questions here to keep the issue tracker clean.


### PR DESCRIPTION
### Description

Closes #23

Adds default `D-needs-triage` label to issues.

Also adds respective `C-feat` and `C-bug` labels.

Disables blank issues so these labels must be applied to new issues.