### PR TITLE
chore(protocol): Empty Scalar Accessor

### DIFF
--- a/crates/protocol/src/info/ecotone.rs
+++ b/crates/protocol/src/info/ecotone.rs
@@ -43,12 +43,10 @@ pub struct L1BlockInfoEcotone {
     pub blob_base_fee_scalar: u32,
     /// The fee scalar for L1 data
     pub base_fee_scalar: u32,
-    /// Indicates that the scalars are empty.
+    /// The l1 fee overhead only used for bedrock fallback cost function.
+    ///
     /// This is an edge case where the first block in ecotone has no scalars,
     /// so the bedrock tx l1 cost function needs to be used.
-    pub empty_scalars: bool,
-    /// The l1 fee overhead used along with the `empty_scalars` field for the
-    /// bedrock tx l1 cost function.
     ///
     /// This field is deprecated in the Ecotone Hardfork.
     pub l1_fee_overhead: U256,
@@ -64,6 +62,11 @@ impl L1BlockInfoEcotone {
     /// The 4 byte selector of "setL1BlockValuesEcotone()"
     pub const L1_INFO_TX_SELECTOR: [u8; 4] = [0x44, 0x0a, 0x5e, 0x20];
 
+    /// Returns whether the scalars are empty.
+    pub const fn empty_scalars(&self) -> bool {
+        self.base_fee_scalar == 0 && self.blob_base_fee_scalar == 0
+    }
+
     /// Encodes the [L1BlockInfoEcotone] object into Ethereum transaction calldata.
     pub fn encode_calldata(&self) -> Bytes {
         let mut buf = Vec::with_capacity(Self::L1_INFO_TX_LEN);
@@ -77,7 +80,6 @@ impl L1BlockInfoEcotone {
         buf.extend_from_slice(U256::from(self.blob_base_fee).to_be_bytes::<32>().as_ref());
         buf.extend_from_slice(self.block_hash.as_ref());
         buf.extend_from_slice(self.batcher_address.into_word().as_ref());
-        // Notice: do not include the `empty_scalars` field in the calldata.
         // Notice: do not include the `l1_fee_overhead` field in the calldata.
         buf.into()
     }
@@ -127,11 +129,9 @@ impl L1BlockInfoEcotone {
             blob_base_fee,
             blob_base_fee_scalar,
             base_fee_scalar,
-            // Notice: the `empty_scalars` field is not included in the calldata.
+            // Notice: the `l1_fee_overhead` field is not included in the calldata.
             // This is used by the evm to indicate that the bedrock tx l1 cost function
             // needs to be used.
-            empty_scalars: false,
-            // Notice: the `l1_fee_overhead` field is not included in the calldata.
             l1_fee_overhead: U256::ZERO,
         })
     }

--- a/crates/protocol/src/info/variant.rs
+++ b/crates/protocol/src/info/variant.rs
@@ -75,7 +75,6 @@ impl L1BlockInfoTx {
                 blob_base_fee: l1_header.blob_fee(BlobParams::cancun()).unwrap_or(1),
                 blob_base_fee_scalar,
                 base_fee_scalar,
-                empty_scalars: false,
                 l1_fee_overhead: U256::ZERO,
             }))
         } else {
@@ -155,7 +154,7 @@ impl L1BlockInfoTx {
     pub const fn empty_scalars(&self) -> bool {
         match self {
             Self::Bedrock(_) => false,
-            Self::Ecotone(L1BlockInfoEcotone { empty_scalars, .. }) => *empty_scalars,
+            Self::Ecotone(ecotone) => ecotone.empty_scalars(),
         }
     }
 
@@ -366,16 +365,22 @@ mod test {
 
     #[test]
     fn test_empty_scalars() {
-        let bedrock = L1BlockInfoTx::Bedrock(L1BlockInfoBedrock { ..Default::default() });
+        let bedrock = L1BlockInfoTx::Bedrock(Default::default());
         assert!(!bedrock.empty_scalars());
 
-        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
-            empty_scalars: true,
-            ..Default::default()
-        });
+        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone::default());
         assert!(ecotone.empty_scalars());
 
-        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone::default());
+        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
+            base_fee_scalar: 456,
+            ..Default::default()
+        });
+        assert!(!ecotone.empty_scalars());
+
+        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
+            blob_base_fee_scalar: 456,
+            ..Default::default()
+        });
         assert!(!ecotone.empty_scalars());
     }
 
@@ -413,7 +418,6 @@ mod test {
             blob_base_fee: 1,
             blob_base_fee_scalar: 810949,
             base_fee_scalar: 1368,
-            empty_scalars: false,
             l1_fee_overhead: U256::ZERO,
         };
 


### PR DESCRIPTION
### Description

Removes the empty scalar marker in favor of a functional method that checks the actual scalar values.

Closes #53.