### PR TITLE
Migrate `TxDeposit` from `op-alloy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,6 @@ maili-provider = { version = "0.1.4", path = "crates/provider", default-features
 maili-registry = { version = "0.1.4", path = "crates/registry", default-features = false }
 maili-rpc = { version = "0.1.4", path = "crates/rpc", default-features = false }
 
-# OP-Alloy
-op-alloy-consensus = { version = "0.9.3", default-features = false }
-
 # Alloy
 alloy-eips = { version = "0.9.2", default-features = false }
 alloy-serde = { version = "0.9.2", default-features = false }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -20,13 +20,21 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-rlp.workspace = true
+
+# `serde` feature
+serde = { workspace = true, optional = true }
+serde_with = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
 
-# serde
-serde = { workspace = true, optional = true }
+# `arbitrary` feature
+arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 # misc
 derive_more = { workspace = true, default-features = false, features = ["display", "from"] }
+
+[dev-dependencies]
+bincode.workspace = true
+rand.workspace = true
 
 [features]
 default = ["std", "serde"]
@@ -42,8 +50,12 @@ serde = [
   "alloy-serde",
   "alloy-primitives/serde"
 ]
-serde-bincode-compat = ["serde"]
+serde-bincode-compat = [
+  "serde",
+  "dep:serde_with"
+]
 arbitrary = [
+  "dep:arbitrary",
   "alloy-consensus/arbitrary",
   "alloy-primitives/arbitrary",
   "alloy-eips/arbitrary",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -52,6 +52,7 @@ serde = [
 ]
 serde-bincode-compat = [
   "serde",
+  "arbitrary",
   "dep:serde_with"
 ]
 arbitrary = [

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -55,6 +55,7 @@ serde-bincode-compat = [
   "dep:serde_with"
 ]
 arbitrary = [
+  "std",
   "dep:arbitrary",
   "alloy-consensus/arbitrary",
   "alloy-primitives/arbitrary",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -18,6 +18,9 @@ workspace = true
 # Alloy
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
+alloy-eips.workspace = true
+alloy-rlp.workspace = true
+alloy-serde = { workspace = true, optional = true }
 
 # serde
 serde = { workspace = true, optional = true }
@@ -27,8 +30,21 @@ derive_more = { workspace = true, default-features = false, features = ["display
 
 [features]
 default = ["std", "serde"]
-std = ["alloy-primitives/std"]
+std = [
+  "alloy-primitives/std",
+  "alloy-serde/std",
+  "alloy-eips/std",
+  "alloy-consensus/std",
+  "alloy-rlp/std",
+]
 serde = [
   "dep:serde",
+  "alloy-serde",
   "alloy-primitives/serde"
+]
+serde-bincode-compat = ["serde"]
+arbitrary = [
+  "alloy-consensus/arbitrary",
+  "alloy-primitives/arbitrary",
+  "alloy-eips/arbitrary",
 ]

--- a/crates/common/src/deposit/envelope.rs
+++ b/crates/common/src/deposit/envelope.rs
@@ -1,4 +1,4 @@
-//! Transaction envelope with support for OP [`DepositTransaction`].
+//! Transaction envelope with support for OP [`TxDeposit`].
 
 use alloy_consensus::Sealed;
 

--- a/crates/common/src/deposit/envelope.rs
+++ b/crates/common/src/deposit/envelope.rs
@@ -4,11 +4,11 @@ use alloy_consensus::Sealed;
 
 use crate::TxDeposit;
 
-/// Transaction envelope that encompasses a [`DepositTransaction`].
+/// Transaction envelope that encompasses a [`TxDeposit`].
 pub trait DepositTxEnvelope {
     /// Returns `true` if the transaction is a deposit transaction.
     fn is_deposit(&self) -> bool;
 
-    /// Returns [`DepositTransaction`] if transaction is a deposit transaction.
+    /// Returns [`TxDeposit`] if transaction is a deposit transaction.
     fn as_deposit(&self) -> Option<&Sealed<TxDeposit>>;
 }

--- a/crates/common/src/deposit/envelope.rs
+++ b/crates/common/src/deposit/envelope.rs
@@ -2,16 +2,13 @@
 
 use alloy_consensus::Sealed;
 
-use crate::DepositTransaction;
+use crate::TxDeposit;
 
 /// Transaction envelope that encompasses a [`DepositTransaction`].
 pub trait DepositTxEnvelope {
-    /// Deposit transaction.
-    type DepositTx: DepositTransaction;
-
     /// Returns `true` if the transaction is a deposit transaction.
     fn is_deposit(&self) -> bool;
 
     /// Returns [`DepositTransaction`] if transaction is a deposit transaction.
-    fn as_deposit(&self) -> Option<&Sealed<Self::DepositTx>>;
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>>;
 }

--- a/crates/common/src/deposit/mod.rs
+++ b/crates/common/src/deposit/mod.rs
@@ -405,7 +405,7 @@ pub fn serde_deposit_tx_rpc<T: serde::Serialize, S: serde::Serializer>(
 
 /// Bincode-compatible [`TxDeposit`] serde implementation.
 #[cfg(feature = "serde-bincode-compat")]
-pub(super) mod serde_bincode_compat {
+pub mod serde_bincode_compat {
     use alloc::borrow::Cow;
     use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -662,8 +662,8 @@ mod tests {
     #[cfg(feature = "serde-bincode-compat")]
     #[test]
     fn test_tx_deposit_bincode_roundtrip() {
-        #[serde_as]
-        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        #[serde_with::serde_as]
+        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
         struct Data {
             #[serde_as(as = "serde_bincode_compat::TxDeposit")]
             transaction: TxDeposit,

--- a/crates/common/src/deposit/mod.rs
+++ b/crates/common/src/deposit/mod.rs
@@ -662,6 +662,9 @@ mod tests {
     #[cfg(feature = "serde-bincode-compat")]
     #[test]
     fn test_tx_deposit_bincode_roundtrip() {
+        use arbitrary::Arbitrary;
+        use rand::Rng;
+
         #[serde_with::serde_as]
         #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
         struct Data {

--- a/crates/common/src/deposit/mod.rs
+++ b/crates/common/src/deposit/mod.rs
@@ -1,4 +1,4 @@
-//! Tramsaction types for Optimism.
+//! Deposit Transaction type.
 
 mod envelope;
 pub use envelope::DepositTxEnvelope;
@@ -9,8 +9,19 @@ pub use source::{
     UserDepositSource,
 };
 
-use alloy_consensus::Transaction;
-use alloy_primitives::B256;
+use alloc::vec::Vec;
+use alloy_consensus::{Sealable, Transaction, Typed2718};
+use alloy_eips::{
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
+    eip2930::AccessList,
+};
+use alloy_primitives::{
+    keccak256, Address, Bytes, ChainId, PrimitiveSignature as Signature, TxHash, TxKind, B256, U256,
+};
+use alloy_rlp::{
+    Buf, BufMut, Decodable, Encodable, Error as DecodeError, Header, EMPTY_STRING_CODE,
+};
+use core::mem;
 
 /// Identifier for an Optimism deposit transaction
 pub const DEPOSIT_TX_TYPE_ID: u8 = 126; // 0x7E
@@ -34,4 +45,638 @@ pub trait DepositTransaction: Transaction {
     /// # Returns
     /// A `bool` indicating if the transaction is a system transaction.
     fn is_system_transaction(&self) -> bool;
+}
+
+/// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct TxDeposit {
+    /// Hash that uniquely identifies the source of the deposit.
+    pub source_hash: B256,
+    /// The address of the sender account.
+    pub from: Address,
+    /// The address of the recipient account, or the null (zero-length) address if the deposited
+    /// transaction is a contract creation.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "TxKind::is_create"))]
+    pub to: TxKind,
+    /// The ETH value to mint on L2.
+    #[cfg_attr(feature = "serde", serde(default, with = "alloy_serde::quantity::opt"))]
+    pub mint: Option<u128>,
+    ///  The ETH value to send to the recipient account.
+    pub value: U256,
+    /// The gas limit for the L2 transaction.
+    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity", rename = "gas"))]
+    pub gas_limit: u64,
+    /// Field indicating if this transaction is exempt from the L2 gas limit.
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            default,
+            with = "alloy_serde::quantity",
+            rename = "isSystemTx",
+            skip_serializing_if = "core::ops::Not::not"
+        )
+    )]
+    pub is_system_transaction: bool,
+    /// Input has two uses depending if transaction is Create or Call (if `to` field is None or
+    /// Some).
+    pub input: Bytes,
+}
+
+impl DepositTransaction for TxDeposit {
+    #[inline]
+    fn source_hash(&self) -> Option<B256> {
+        Some(self.source_hash)
+    }
+
+    #[inline]
+    fn mint(&self) -> Option<u128> {
+        self.mint
+    }
+
+    #[inline]
+    fn is_system_transaction(&self) -> bool {
+        self.is_system_transaction
+    }
+}
+
+impl TxDeposit {
+    /// Decodes the inner [TxDeposit] fields from RLP bytes.
+    ///
+    /// NOTE: This assumes a RLP header has already been decoded, and _just_ decodes the following
+    /// RLP fields in the following order:
+    ///
+    /// - `source_hash`
+    /// - `from`
+    /// - `to`
+    /// - `mint`
+    /// - `value`
+    /// - `gas_limit`
+    /// - `is_system_transaction`
+    /// - `input`
+    pub fn rlp_decode_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self {
+            source_hash: Decodable::decode(buf)?,
+            from: Decodable::decode(buf)?,
+            to: Decodable::decode(buf)?,
+            mint: if *buf.first().ok_or(DecodeError::InputTooShort)? == EMPTY_STRING_CODE {
+                buf.advance(1);
+                None
+            } else {
+                Some(Decodable::decode(buf)?)
+            },
+            value: Decodable::decode(buf)?,
+            gas_limit: Decodable::decode(buf)?,
+            is_system_transaction: Decodable::decode(buf)?,
+            input: Decodable::decode(buf)?,
+        })
+    }
+
+    /// Decodes the transaction from RLP bytes.
+    pub fn rlp_decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+
+        if header.payload_length > remaining {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let this = Self::rlp_decode_fields(buf)?;
+
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        Ok(this)
+    }
+
+    /// Outputs the length of the transaction's fields, without a RLP header or length of the
+    /// eip155 fields.
+    pub(crate) fn rlp_encoded_fields_length(&self) -> usize {
+        self.source_hash.length()
+            + self.from.length()
+            + self.to.length()
+            + self.mint.map_or(1, |mint| mint.length())
+            + self.value.length()
+            + self.gas_limit.length()
+            + self.is_system_transaction.length()
+            + self.input.0.length()
+    }
+
+    /// Encodes only the transaction's fields into the desired buffer, without a RLP header.
+    /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md#the-deposited-transaction-type>
+    pub(crate) fn rlp_encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+        self.source_hash.encode(out);
+        self.from.encode(out);
+        self.to.encode(out);
+        if let Some(mint) = self.mint {
+            mint.encode(out);
+        } else {
+            out.put_u8(EMPTY_STRING_CODE);
+        }
+        self.value.encode(out);
+        self.gas_limit.encode(out);
+        self.is_system_transaction.encode(out);
+        self.input.encode(out);
+    }
+
+    /// Calculates a heuristic for the in-memory size of the [TxDeposit] transaction.
+    #[inline]
+    pub fn size(&self) -> usize {
+        mem::size_of::<B256>() + // source_hash
+        mem::size_of::<Address>() + // from
+        self.to.size() + // to
+        mem::size_of::<Option<u128>>() + // mint
+        mem::size_of::<U256>() + // value
+        mem::size_of::<u128>() + // gas_limit
+        mem::size_of::<bool>() + // is_system_transaction
+        self.input.len() // input
+    }
+
+    /// Create an rlp header for the transaction.
+    fn rlp_header(&self) -> Header {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }
+    }
+
+    /// RLP encodes the transaction.
+    pub fn rlp_encode(&self, out: &mut dyn BufMut) {
+        self.rlp_header().encode(out);
+        self.rlp_encode_fields(out);
+    }
+
+    /// Get the length of the transaction when RLP encoded.
+    pub fn rlp_encoded_length(&self) -> usize {
+        self.rlp_header().length_with_payload()
+    }
+
+    /// Get the length of the transaction when EIP-2718 encoded. This is the
+    /// 1 byte type flag + the length of the RLP encoded transaction.
+    pub fn eip2718_encoded_length(&self) -> usize {
+        self.rlp_encoded_length() + 1
+    }
+
+    fn network_header(&self) -> Header {
+        Header { list: false, payload_length: self.eip2718_encoded_length() }
+    }
+
+    /// Get the length of the transaction when network encoded. This is the
+    /// EIP-2718 encoded length with an outer RLP header.
+    pub fn network_encoded_length(&self) -> usize {
+        self.network_header().length_with_payload()
+    }
+
+    /// Network encode the transaction with the given signature.
+    pub fn network_encode(&self, out: &mut dyn BufMut) {
+        self.network_header().encode(out);
+        self.encode_2718(out);
+    }
+
+    /// Calculate the transaction hash.
+    pub fn tx_hash(&self) -> TxHash {
+        let mut buf = Vec::with_capacity(self.eip2718_encoded_length());
+        self.encode_2718(&mut buf);
+        keccak256(&buf)
+    }
+
+    /// Returns the signature for the optimism deposit transactions, which don't include a
+    /// signature.
+    pub fn signature() -> Signature {
+        Signature::new(U256::ZERO, U256::ZERO, false)
+    }
+}
+
+impl Typed2718 for TxDeposit {
+    fn ty(&self) -> u8 {
+        DEPOSIT_TX_TYPE_ID
+    }
+}
+
+impl Transaction for TxDeposit {
+    fn chain_id(&self) -> Option<ChainId> {
+        None
+    }
+
+    fn nonce(&self) -> u64 {
+        0u64
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.gas_limit
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        None
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        0
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        None
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        0
+    }
+
+    fn effective_gas_price(&self, _: Option<u64>) -> u128 {
+        0
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        false
+    }
+
+    fn kind(&self) -> TxKind {
+        self.to
+    }
+
+    fn is_create(&self) -> bool {
+        self.to.is_create()
+    }
+
+    fn value(&self) -> U256 {
+        self.value
+    }
+
+    fn input(&self) -> &Bytes {
+        &self.input
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        None
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
+        None
+    }
+}
+
+impl Encodable2718 for TxDeposit {
+    fn type_flag(&self) -> Option<u8> {
+        Some(DEPOSIT_TX_TYPE_ID)
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        self.eip2718_encoded_length()
+    }
+
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        out.put_u8(DEPOSIT_TX_TYPE_ID);
+        self.rlp_encode(out);
+    }
+}
+
+impl Decodable2718 for TxDeposit {
+    fn typed_decode(ty: u8, data: &mut &[u8]) -> Eip2718Result<Self> {
+        if ty != DEPOSIT_TX_TYPE_ID {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
+        let tx = Self::decode(data)?;
+        Ok(tx)
+    }
+
+    fn fallback_decode(data: &mut &[u8]) -> Eip2718Result<Self> {
+        let tx = Self::decode(data)?;
+        Ok(tx)
+    }
+}
+
+impl alloy_rlp::Encodable for TxDeposit {
+    fn encode(&self, out: &mut dyn BufMut) {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length() }.encode(out);
+        self.rlp_encode_fields(out);
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.rlp_encoded_fields_length();
+        Header { list: true, payload_length }.length() + payload_length
+    }
+}
+
+impl alloy_rlp::Decodable for TxDeposit {
+    fn decode(data: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Self::rlp_decode(data)
+    }
+}
+
+impl Sealable for TxDeposit {
+    fn hash_slow(&self) -> B256 {
+        self.tx_hash()
+    }
+}
+
+/// Deposit transactions don't have a signature, however, we include an empty signature in the
+/// response for better compatibility.
+///
+/// This function can be used as `serialize_with` serde attribute for the [`TxDeposit`] and will
+/// flatten [`TxDeposit::signature`] into response.
+#[cfg(feature = "serde")]
+pub fn serde_deposit_tx_rpc<T: serde::Serialize, S: serde::Serializer>(
+    value: &T,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct SerdeHelper<'a, T> {
+        #[serde(flatten)]
+        value: &'a T,
+        #[serde(flatten)]
+        signature: Signature,
+    }
+
+    SerdeHelper { value, signature: TxDeposit::signature() }.serialize(serializer)
+}
+
+/// Bincode-compatible [`TxDeposit`] serde implementation.
+#[cfg(feature = "serde-bincode-compat")]
+pub(super) mod serde_bincode_compat {
+    use alloc::borrow::Cow;
+    use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    /// Bincode-compatible [`super::TxDeposit`] serde implementation.
+    ///
+    /// Intended to use with the [`serde_with::serde_as`] macro in the following way:
+    /// ```rust
+    /// use op_alloy_consensus::{serde_bincode_compat, TxDeposit};
+    /// use serde::{Deserialize, Serialize};
+    /// use serde_with::serde_as;
+    ///
+    /// #[serde_as]
+    /// #[derive(Serialize, Deserialize)]
+    /// struct Data {
+    ///     #[serde_as(as = "serde_bincode_compat::TxDeposit")]
+    ///     transaction: TxDeposit,
+    /// }
+    /// ```
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct TxDeposit<'a> {
+        source_hash: B256,
+        from: Address,
+        #[serde(default)]
+        to: TxKind,
+        #[serde(default)]
+        mint: Option<u128>,
+        value: U256,
+        gas_limit: u64,
+        is_system_transaction: bool,
+        input: Cow<'a, Bytes>,
+    }
+
+    impl<'a> From<&'a super::TxDeposit> for TxDeposit<'a> {
+        fn from(value: &'a super::TxDeposit) -> Self {
+            Self {
+                source_hash: value.source_hash,
+                from: value.from,
+                to: value.to,
+                mint: value.mint,
+                value: value.value,
+                gas_limit: value.gas_limit,
+                is_system_transaction: value.is_system_transaction,
+                input: Cow::Borrowed(&value.input),
+            }
+        }
+    }
+
+    impl<'a> From<TxDeposit<'a>> for super::TxDeposit {
+        fn from(value: TxDeposit<'a>) -> Self {
+            Self {
+                source_hash: value.source_hash,
+                from: value.from,
+                to: value.to,
+                mint: value.mint,
+                value: value.value,
+                gas_limit: value.gas_limit,
+                is_system_transaction: value.is_system_transaction,
+                input: value.input.into_owned(),
+            }
+        }
+    }
+
+    impl SerializeAs<super::TxDeposit> for TxDeposit<'_> {
+        fn serialize_as<S>(source: &super::TxDeposit, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            TxDeposit::from(source).serialize(serializer)
+        }
+    }
+
+    impl<'de> DeserializeAs<'de, super::TxDeposit> for TxDeposit<'de> {
+        fn deserialize_as<D>(deserializer: D) -> Result<super::TxDeposit, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            TxDeposit::deserialize(deserializer).map(Into::into)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+    use alloy_rlp::BytesMut;
+
+    #[test]
+    fn test_deposit_transaction_trait() {
+        let tx = TxDeposit {
+            source_hash: B256::with_last_byte(42),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::from(1000),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        assert_eq!(tx.source_hash(), Some(B256::with_last_byte(42)));
+        assert_eq!(tx.mint(), Some(100));
+        assert!(tx.is_system_transaction());
+    }
+
+    #[test]
+    fn test_deposit_transaction_without_mint() {
+        let tx = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: None,
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: false,
+            input: Bytes::default(),
+        };
+
+        assert_eq!(tx.source_hash(), Some(B256::default()));
+        assert_eq!(tx.mint(), None);
+        assert!(!tx.is_system_transaction());
+    }
+
+    #[test]
+    fn test_deposit_transaction_to_contract() {
+        let contract_address = Address::with_last_byte(0xFF);
+        let tx = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::Call(contract_address),
+            mint: Some(200),
+            value: U256::from(500),
+            gas_limit: 100000,
+            is_system_transaction: false,
+            input: Bytes::from_static(&[1, 2, 3]),
+        };
+
+        assert_eq!(tx.source_hash(), Some(B256::default()));
+        assert_eq!(tx.mint(), Some(200));
+        assert!(!tx.is_system_transaction());
+        assert_eq!(tx.kind(), TxKind::Call(contract_address));
+    }
+
+    #[test]
+    fn test_rlp_roundtrip() {
+        let bytes = Bytes::from_static(&hex!("7ef9015aa044bae9d41b8380d781187b426c6fe43df5fb2fb57bd4466ef6a701e1f01e015694deaddeaddeaddeaddeaddeaddeaddeaddead000194420000000000000000000000000000000000001580808408f0d18001b90104015d8eb900000000000000000000000000000000000000000000000000000000008057650000000000000000000000000000000000000000000000000000000063d96d10000000000000000000000000000000000000000000000000000000000009f35273d89754a1e0387b89520d989d3be9c37c1f32495a88faf1ea05c61121ab0d1900000000000000000000000000000000000000000000000000000000000000010000000000000000000000002d679b567db6187c0c8323fa982cfb88b74dbcc7000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f4240"));
+        let tx_a = TxDeposit::decode(&mut bytes[1..].as_ref()).unwrap();
+        let mut buf_a = BytesMut::default();
+        tx_a.encode(&mut buf_a);
+        assert_eq!(&buf_a[..], &bytes[1..]);
+    }
+
+    #[test]
+    fn test_encode_decode_fields() {
+        let original = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        let mut buffer = BytesMut::new();
+        original.rlp_encode_fields(&mut buffer);
+        let decoded = TxDeposit::rlp_decode_fields(&mut &buffer[..]).expect("Failed to decode");
+
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_encode_with_and_without_header() {
+        let tx_deposit = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        let mut buffer_with_header = BytesMut::new();
+        tx_deposit.encode(&mut buffer_with_header);
+
+        let mut buffer_without_header = BytesMut::new();
+        tx_deposit.rlp_encode_fields(&mut buffer_without_header);
+
+        assert!(buffer_with_header.len() > buffer_without_header.len());
+    }
+
+    #[test]
+    fn test_payload_length() {
+        let tx_deposit = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        assert!(tx_deposit.size() > tx_deposit.rlp_encoded_fields_length());
+    }
+
+    #[test]
+    fn test_encode_inner_with_and_without_header() {
+        let tx_deposit = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        let mut buffer_with_header = BytesMut::new();
+        tx_deposit.network_encode(&mut buffer_with_header);
+
+        let mut buffer_without_header = BytesMut::new();
+        tx_deposit.encode_2718(&mut buffer_without_header);
+
+        assert!(buffer_with_header.len() > buffer_without_header.len());
+    }
+
+    #[test]
+    fn test_payload_length_header() {
+        let tx_deposit = TxDeposit {
+            source_hash: B256::default(),
+            from: Address::default(),
+            to: TxKind::default(),
+            mint: Some(100),
+            value: U256::default(),
+            gas_limit: 50000,
+            is_system_transaction: true,
+            input: Bytes::default(),
+        };
+
+        let total_len = tx_deposit.network_encoded_length();
+        let len_without_header = tx_deposit.eip2718_encoded_length();
+
+        assert!(total_len > len_without_header);
+    }
+
+    #[cfg(feature = "serde-bincode-compat")]
+    #[test]
+    fn test_tx_deposit_bincode_roundtrip() {
+        #[serde_as]
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Data {
+            #[serde_as(as = "serde_bincode_compat::TxDeposit")]
+            transaction: TxDeposit,
+        }
+
+        let mut bytes = [0u8; 1024];
+        rand::thread_rng().fill(bytes.as_mut_slice());
+        let data = Data {
+            transaction: TxDeposit::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap(),
+        };
+
+        let encoded = bincode::serialize(&data).unwrap();
+        let decoded: Data = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -10,9 +10,11 @@
 extern crate alloc;
 
 mod deposit;
+#[cfg(feature = "serde")]
+pub use deposit::serde_deposit_tx_rpc;
 pub use deposit::{
     DepositSourceDomain, DepositSourceDomainIdentifier, DepositTransaction, DepositTxEnvelope,
-    L1InfoDepositSource, UpgradeDepositSource, UserDepositSource, DEPOSIT_TX_TYPE_ID,
+    L1InfoDepositSource, TxDeposit, UpgradeDepositSource, UserDepositSource, DEPOSIT_TX_TYPE_ID,
 };
 
 mod superchain;

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -10,6 +10,8 @@
 extern crate alloc;
 
 mod deposit;
+#[cfg(feature = "serde-bincode-compat")]
+pub use deposit::serde_bincode_compat;
 #[cfg(feature = "serde")]
 pub use deposit::serde_deposit_tx_rpc;
 pub use deposit::{

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -67,6 +67,11 @@ op-alloy-consensus.version = "0.9.3"
 
 [features]
 default = ["serde", "std"]
+std = [
+  "maili-genesis/std",
+  "maili-common/std",
+  "brotli/std",
+]
 test-utils = [
   "dep:spin",
   "dep:tracing-subscriber",
@@ -75,17 +80,15 @@ arbitrary = [
   "std",
   "dep:arbitrary",
   "maili-genesis/arbitrary",
+  "maili-common/arbitrary",
   "alloy-consensus/arbitrary",
   "alloy-eips/arbitrary",
   "alloy-primitives/rand",
   "alloy-primitives/arbitrary",
 ]
-std = [
-  "maili-genesis/std",
-  "brotli/std",
-]
 serde = [
   "dep:serde",
   "dep:alloy-serde",
   "maili-genesis/serde",
+  "maili-common/serde",
 ]

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -63,7 +63,6 @@ tokio = { workspace = true, features = ["full"] }
 arbitrary = { workspace = true, features = ["derive"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
-#op-alloy-consensus.version = "0.9.3"
 
 [features]
 default = ["serde", "std"]

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -63,7 +63,7 @@ tokio = { workspace = true, features = ["full"] }
 arbitrary = { workspace = true, features = ["derive"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
-op-alloy-consensus.version = "0.9.3"
+#op-alloy-consensus.version = "0.9.3"
 
 [features]
 default = ["serde", "std"]

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -19,9 +19,6 @@ workspace = true
 maili-common.workspace = true
 maili-genesis.workspace = true
 
-# OP-Alloy
-op-alloy-consensus.workspace = true
-
 # Alloy
 alloy-primitives = { workspace = true, features = ["map"] }
 alloy-sol-types.workspace = true
@@ -66,6 +63,7 @@ tokio = { workspace = true, features = ["full"] }
 arbitrary = { workspace = true, features = ["derive"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
+op-alloy-consensus.version = "0.9.3"
 
 [features]
 default = ["serde", "std"]
@@ -83,15 +81,11 @@ arbitrary = [
   "alloy-primitives/arbitrary",
 ]
 std = [
-  "maili-common/std",
   "maili-genesis/std",
-  "op-alloy-consensus/std",
   "brotli/std",
 ]
 serde = [
   "dep:serde",
   "dep:alloy-serde",
-  "maili-common/serde",
   "maili-genesis/serde",
-  "op-alloy-consensus/serde",
 ]

--- a/crates/protocol/examples/batch_to_frames.rs
+++ b/crates/protocol/examples/batch_to_frames.rs
@@ -55,10 +55,9 @@ fn main() {
 
 #[cfg(feature = "std")]
 fn example_transactions() -> Vec<alloy_primitives::Bytes> {
-    use alloy_consensus::{SignableTransaction, TxEip1559};
+    use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
     use alloy_eips::eip2718::{Decodable2718, Encodable2718};
     use alloy_primitives::{Address, PrimitiveSignature, U256};
-    use op_alloy_consensus::OpTxEnvelope;
 
     let mut transactions = Vec::new();
 
@@ -76,12 +75,12 @@ fn example_transactions() -> Vec<alloy_primitives::Bytes> {
     };
     let sig = PrimitiveSignature::test_signature();
     let tx_signed = tx.into_signed(sig);
-    let envelope: OpTxEnvelope = tx_signed.into();
+    let envelope: TxEnvelope = tx_signed.into();
     let encoded = envelope.encoded_2718();
     transactions.push(encoded.clone().into());
     let mut slice = encoded.as_slice();
-    let decoded = OpTxEnvelope::decode_2718(&mut slice).unwrap();
-    assert!(matches!(decoded, OpTxEnvelope::Eip1559(_)));
+    let decoded = TxEnvelope::decode_2718(&mut slice).unwrap();
+    assert!(matches!(decoded, TxEnvelope::Eip1559(_)));
 
     // Second transaction in the batch.
     let tx = TxEip1559 {
@@ -97,12 +96,12 @@ fn example_transactions() -> Vec<alloy_primitives::Bytes> {
     };
     let sig = PrimitiveSignature::test_signature();
     let tx_signed = tx.into_signed(sig);
-    let envelope: OpTxEnvelope = tx_signed.into();
+    let envelope: TxEnvelope = tx_signed.into();
     let encoded = envelope.encoded_2718();
     transactions.push(encoded.clone().into());
     let mut slice = encoded.as_slice();
-    let decoded = OpTxEnvelope::decode_2718(&mut slice).unwrap();
-    assert!(matches!(decoded, OpTxEnvelope::Eip1559(_)));
+    let decoded = TxEnvelope::decode_2718(&mut slice).unwrap();
+    assert!(matches!(decoded, TxEnvelope::Eip1559(_)));
 
     transactions
 }

--- a/crates/protocol/examples/frames_to_batch.rs
+++ b/crates/protocol/examples/frames_to_batch.rs
@@ -1,11 +1,10 @@
 //! This example decodes raw [Frame]s and reads them into a [Channel] and into a [SingleBatch].
 
-use alloy_consensus::{SignableTransaction, TxEip1559};
+use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{hex, Address, BlockHash, Bytes, PrimitiveSignature, U256};
 use maili_genesis::RollupConfig;
 use maili_protocol::{decompress_brotli, Batch, BlockInfo, Channel, Frame, SingleBatch};
-use op_alloy_consensus::OpTxEnvelope;
 
 fn main() {
     // Raw frame data taken from the `encode_channel` example.
@@ -69,12 +68,12 @@ fn example_transactions() -> Vec<Bytes> {
     };
     let sig = PrimitiveSignature::test_signature();
     let tx_signed = tx.into_signed(sig);
-    let envelope: OpTxEnvelope = tx_signed.into();
+    let envelope: TxEnvelope = tx_signed.into();
     let encoded = envelope.encoded_2718();
     transactions.push(encoded.clone().into());
     let mut slice = encoded.as_slice();
-    let decoded = OpTxEnvelope::decode_2718(&mut slice).unwrap();
-    assert!(matches!(decoded, OpTxEnvelope::Eip1559(_)));
+    let decoded = TxEnvelope::decode_2718(&mut slice).unwrap();
+    assert!(matches!(decoded, TxEnvelope::Eip1559(_)));
 
     // Second transaction in the batch.
     let tx = TxEip1559 {
@@ -90,12 +89,12 @@ fn example_transactions() -> Vec<Bytes> {
     };
     let sig = PrimitiveSignature::test_signature();
     let tx_signed = tx.into_signed(sig);
-    let envelope: OpTxEnvelope = tx_signed.into();
+    let envelope: TxEnvelope = tx_signed.into();
     let encoded = envelope.encoded_2718();
     transactions.push(encoded.clone().into());
     let mut slice = encoded.as_slice();
-    let decoded = OpTxEnvelope::decode_2718(&mut slice).unwrap();
-    assert!(matches!(decoded, OpTxEnvelope::Eip1559(_)));
+    let decoded = TxEnvelope::decode_2718(&mut slice).unwrap();
+    assert!(matches!(decoded, TxEnvelope::Eip1559(_)));
 
     transactions
 }

--- a/crates/protocol/src/batch/single.rs
+++ b/crates/protocol/src/batch/single.rs
@@ -286,10 +286,9 @@ mod tests {
     }
 
     fn example_transactions() -> Vec<Bytes> {
-        use alloy_consensus::{SignableTransaction, TxEip1559};
+        use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
         use alloy_eips::eip2718::{Decodable2718, Encodable2718};
         use alloy_primitives::{Address, PrimitiveSignature, U256};
-        use op_alloy_consensus::OpTxEnvelope;
 
         let mut transactions = Vec::new();
 
@@ -307,12 +306,12 @@ mod tests {
         };
         let sig = PrimitiveSignature::test_signature();
         let tx_signed = tx.into_signed(sig);
-        let envelope: OpTxEnvelope = tx_signed.into();
+        let envelope: TxEnvelope = tx_signed.into();
         let encoded = envelope.encoded_2718();
         transactions.push(encoded.clone().into());
         let mut slice = encoded.as_slice();
-        let decoded = OpTxEnvelope::decode_2718(&mut slice).unwrap();
-        assert!(matches!(decoded, OpTxEnvelope::Eip1559(_)));
+        let decoded = TxEnvelope::decode_2718(&mut slice).unwrap();
+        assert!(matches!(decoded, TxEnvelope::Eip1559(_)));
 
         // Second transaction in the batch.
         let tx = TxEip1559 {
@@ -328,12 +327,12 @@ mod tests {
         };
         let sig = PrimitiveSignature::test_signature();
         let tx_signed = tx.into_signed(sig);
-        let envelope: OpTxEnvelope = tx_signed.into();
+        let envelope: TxEnvelope = tx_signed.into();
         let encoded = envelope.encoded_2718();
         transactions.push(encoded.clone().into());
         let mut slice = encoded.as_slice();
-        let decoded = OpTxEnvelope::decode_2718(&mut slice).unwrap();
-        assert!(matches!(decoded, OpTxEnvelope::Eip1559(_)));
+        let decoded = TxEnvelope::decode_2718(&mut slice).unwrap();
+        assert!(matches!(decoded, TxEnvelope::Eip1559(_)));
 
         transactions
     }

--- a/crates/protocol/src/batch/span.rs
+++ b/crates/protocol/src/batch/span.rs
@@ -490,7 +490,7 @@ impl SpanBatch {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    /*use super::*;
     use crate::test_utils::{CollectingLayer, TestBatchValidator, TraceStorage};
     use alloc::vec;
     use alloy_consensus::Header;
@@ -559,7 +559,7 @@ mod tests {
         assert!(!batch.check_parent_hash(invalid));
     }
 
-    /*#[tokio::test]
+    #[tokio::test]
     async fn test_check_batch_missing_l1_block_input() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());

--- a/crates/protocol/src/batch/span.rs
+++ b/crates/protocol/src/batch/span.rs
@@ -490,16 +490,49 @@ impl SpanBatch {
 
 #[cfg(test)]
 mod tests {
-    /*use super::*;
+    use super::*;
     use crate::test_utils::{CollectingLayer, TestBatchValidator, TraceStorage};
     use alloc::vec;
-    use alloy_consensus::Header;
-    use alloy_eips::BlockNumHash;
+    use alloy_consensus::{constants::EIP1559_TX_TYPE_ID, Block, Header, Typed2718};
+    use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
     use alloy_primitives::{b256, Bytes};
+    use maili_common::TxDeposit;
     use maili_genesis::ChainGenesis;
-    use op_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType};
     use tracing::Level;
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    #[derive(Clone, Debug)]
+    struct NoopTx;
+
+    impl DepositTxEnvelope for NoopTx {
+        fn is_deposit(&self) -> bool {
+            false
+        }
+
+        fn as_deposit(&self) -> Option<&alloy_consensus::Sealed<TxDeposit>> {
+            None
+        }
+    }
+
+    impl Typed2718 for NoopTx {
+        fn ty(&self) -> u8 {
+            u8::MAX
+        }
+    }
+
+    impl Encodable2718 for NoopTx {
+        fn type_flag(&self) -> Option<u8> {
+            Some(u8::MAX)
+        }
+
+        fn encode_2718(&self, _out: &mut dyn alloy_rlp::BufMut) {}
+
+        fn encode_2718_len(&self) -> usize {
+            0
+        }
+    }
+
+    type TestOpBlock = Block<NoopTx>;
 
     #[test]
     fn test_timestamp() {
@@ -569,7 +602,7 @@ mod tests {
         let l1_blocks = vec![];
         let l2_safe_head = L2BlockInfo::default();
         let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
         let batch = SpanBatch::default();
         assert_eq!(
             batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
@@ -590,7 +623,7 @@ mod tests {
         let l1_blocks = vec![BlockInfo::default()];
         let l2_safe_head = L2BlockInfo::default();
         let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
         let batch = SpanBatch::default();
         assert_eq!(
             batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
@@ -612,7 +645,7 @@ mod tests {
         let l1_blocks = vec![block];
         let l2_safe_head = L2BlockInfo::default();
         let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
         let first = SpanBatchElement { epoch_num: 10, ..Default::default() };
         let batch = SpanBatch { batches: vec![first], ..Default::default() };
         assert_eq!(
@@ -639,7 +672,7 @@ mod tests {
         let l1_blocks = vec![block];
         let l2_safe_head = L2BlockInfo::default();
         let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let batch = SpanBatch { batches: vec![first], ..Default::default() };
         assert_eq!(
@@ -670,7 +703,7 @@ mod tests {
             ..Default::default()
         };
         let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
         let first = SpanBatchElement { epoch_num: 10, timestamp: 21, ..Default::default() };
         let batch = SpanBatch { batches: vec![first], ..Default::default() };
         assert_eq!(
@@ -698,7 +731,7 @@ mod tests {
             ..Default::default()
         };
         let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let batch = SpanBatch { batches: vec![first], ..Default::default() };
         assert_eq!(
@@ -724,7 +757,7 @@ mod tests {
             ..Default::default()
         };
         let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
         let first = SpanBatchElement { epoch_num: 10, timestamp: 11, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 21, ..Default::default() };
         let batch = SpanBatch { batches: vec![first, second], ..Default::default() };
@@ -751,7 +784,7 @@ mod tests {
             ..Default::default()
         };
         let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
         let first = SpanBatchElement { epoch_num: 10, timestamp: 8, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 20, ..Default::default() };
         let batch = SpanBatch { batches: vec![first, second], ..Default::default() };
@@ -778,7 +811,7 @@ mod tests {
             ..Default::default()
         };
         let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 20, ..Default::default() };
         let batch = SpanBatch { batches: vec![first, second], ..Default::default() };
@@ -811,7 +844,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 9, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         fetcher.short_circuit = true;
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
@@ -857,7 +890,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 20, ..Default::default() };
@@ -907,7 +940,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 8, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 20, ..Default::default() };
@@ -966,7 +999,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 9, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 20, ..Default::default() };
@@ -1022,7 +1055,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 9, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 20, ..Default::default() };
@@ -1075,7 +1108,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 14, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 20, ..Default::default() };
@@ -1134,7 +1167,7 @@ mod tests {
             block_info: BlockInfo { number: 40, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement { epoch_num: 10, timestamp: 20, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 10, timestamp: 20, ..Default::default() };
@@ -1190,7 +1223,7 @@ mod tests {
             block_info: BlockInfo { number: 40, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement { epoch_num: 10, timestamp: 20, transactions: vec![] };
         let second = SpanBatchElement { epoch_num: 10, timestamp: 20, transactions: vec![] };
@@ -1249,7 +1282,7 @@ mod tests {
             block_info: BlockInfo { number: 40, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement {
             epoch_num: 10,
@@ -1318,7 +1351,7 @@ mod tests {
             block_info: BlockInfo { number: 40, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement {
             epoch_num: 10,
@@ -1383,9 +1416,9 @@ mod tests {
             block_info: BlockInfo { number: 40, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
-        let filler_bytes = Bytes::copy_from_slice(&[OpTxType::Eip1559 as u8]);
+        let filler_bytes = Bytes::copy_from_slice(&[EIP1559_TX_TYPE_ID]);
         let first = SpanBatchElement {
             epoch_num: 10,
             timestamp: 20,
@@ -1394,7 +1427,7 @@ mod tests {
         let second = SpanBatchElement {
             epoch_num: 10,
             timestamp: 20,
-            transactions: vec![Bytes::copy_from_slice(&[OpTxType::Deposit as u8])],
+            transactions: vec![Bytes::copy_from_slice(&[DEPOSIT_TX_TYPE_ID])],
         };
         let third =
             SpanBatchElement { epoch_num: 11, timestamp: 20, transactions: vec![filler_bytes] };
@@ -1448,7 +1481,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 9, ..Default::default() },
             ..Default::default()
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> =
+        let mut fetcher: TestBatchValidator<NoopTx> =
             TestBatchValidator { blocks: vec![l2_block], ..Default::default() };
         let first = SpanBatchElement { epoch_num: 10, timestamp: 10, ..Default::default() };
         let second = SpanBatchElement { epoch_num: 11, timestamp: 20, ..Default::default() };
@@ -1501,7 +1534,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 9, ..Default::default() },
             ..Default::default()
         };
-        let block = OpBlock {
+        let block = TestOpBlock {
             header: Header { number: 41, ..Default::default() },
             body: alloy_consensus::BlockBody {
                 transactions: Vec::new(),
@@ -1509,7 +1542,7 @@ mod tests {
                 withdrawals: None,
             },
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator {
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator {
             blocks: vec![l2_block],
             op_blocks: vec![block],
             ..Default::default()
@@ -1575,7 +1608,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 9, ..Default::default() },
             ..Default::default()
         };
-        let block = OpBlock {
+        let block = TestOpBlock {
             header: Header { number: 41, ..Default::default() },
             body: alloy_consensus::BlockBody {
                 transactions: Vec::new(),
@@ -1583,7 +1616,7 @@ mod tests {
                 withdrawals: None,
             },
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator {
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator {
             blocks: vec![l2_block],
             op_blocks: vec![block],
             ..Default::default()
@@ -1651,7 +1684,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 9, ..Default::default() },
             ..Default::default()
         };
-        let block = OpBlock {
+        let block = TestOpBlock {
             header: Header { number: 41, ..Default::default() },
             body: alloy_consensus::BlockBody {
                 transactions: Vec::new(),
@@ -1659,7 +1692,7 @@ mod tests {
                 withdrawals: None,
             },
         };
-        let mut fetcher: TestBatchValidator<OpTxEnvelope> = TestBatchValidator {
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator {
             blocks: vec![l2_block],
             op_blocks: vec![block],
             ..Default::default()
@@ -1677,5 +1710,5 @@ mod tests {
             BatchValidity::Accept
         );
         assert!(trace_store.is_empty());
-    }*/
+    }
 }

--- a/crates/protocol/src/batch/span.rs
+++ b/crates/protocol/src/batch/span.rs
@@ -559,7 +559,7 @@ mod tests {
         assert!(!batch.check_parent_hash(invalid));
     }
 
-    #[tokio::test]
+    /*#[tokio::test]
     async fn test_check_batch_missing_l1_block_input() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
@@ -1677,5 +1677,5 @@ mod tests {
             BatchValidity::Accept
         );
         assert!(trace_store.is_empty());
-    }
+    }*/
 }

--- a/crates/protocol/src/deposits.rs
+++ b/crates/protocol/src/deposits.rs
@@ -3,7 +3,7 @@
 use alloc::{string::String, vec::Vec};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{b256, keccak256, Address, Bytes, Log, TxKind, B256, U256, U64};
-use op_alloy_consensus::TxDeposit;
+use maili_common::TxDeposit;
 
 /// Deposit log event abi signature.
 pub const DEPOSIT_EVENT_ABI: &str = "TransactionDeposited(address,address,uint256,bytes)";
@@ -18,7 +18,7 @@ pub const DEPOSIT_EVENT_ABI_HASH: B256 =
 /// The initial version of the deposit event log.
 pub const DEPOSIT_EVENT_VERSION_0: B256 = B256::ZERO;
 
-/// An [op_alloy_consensus::TxDeposit] validation error.
+/// An [`TxDeposit`] validation error.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum DepositError {
     /// Unexpected number of deposit event log topics.

--- a/crates/protocol/src/info/variant.rs
+++ b/crates/protocol/src/info/variant.rs
@@ -5,8 +5,8 @@ use alloc::{format, string::ToString};
 use alloy_consensus::Header;
 use alloy_eips::{eip7840::BlobParams, BlockNumHash};
 use alloy_primitives::{address, Address, Bytes, Sealable, Sealed, TxKind, B256, U256};
+use maili_common::TxDeposit;
 use maili_genesis::{RollupConfig, SystemConfig};
-use op_alloy_consensus::TxDeposit;
 
 use crate::{
     BlockInfoError, DecodeError, DepositSourceDomain, L1BlockInfoBedrock, L1BlockInfoEcotone,


### PR DESCRIPTION
Migrates `TxDeposit` from `op-alloy`. Removes dependency on `op-alloy` in lib.