### PR TITLE
chore(docs): Add missing links in book

### DIFF
--- a/book/src/links.md
+++ b/book/src/links.md
@@ -9,6 +9,7 @@
 [maili-provider]: https://crates.io/crates/maili-provider
 [maili-registry]: https://crates.io/crates/maili-registry
 [maili-common]: https://crates.io/crates/maili-common
+[maili-genesis]: https://crates.io/crates/maili-genesis
 
 <!-- maili-protocol -->
 

--- a/book/src/links.md
+++ b/book/src/links.md
@@ -10,6 +10,7 @@
 [maili-registry]: https://crates.io/crates/maili-registry
 [maili-common]: https://crates.io/crates/maili-common
 [maili-genesis]: https://crates.io/crates/maili-genesis
+[maili-rpc]: https://crates.io/crates/maili-rpc
 
 <!-- maili-protocol -->
 


### PR DESCRIPTION
Adds `maili-rpc` and `maili-genesis` to book links