### PR TITLE
chore(rpc): Export RPC APIs from crate root

### DIFF
--- a/crates/rpc/src/api.rs
+++ b/crates/rpc/src/api.rs
@@ -154,13 +154,14 @@ pub trait MinerApiExt {
 }
 
 /// Supervisor API for interop.
-#[rpc(client, namespace = "supervisor")]
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "supervisor"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "supervisor"))]
 pub trait SupervisorApi {
     /// Checks if the given messages meet the given minimum safety level.
     #[method(name = "checkMessages")]
     async fn check_messages(
         &self,
-        messages: &[ExecutingMessage],
+        messages: Vec<ExecutingMessage>,
         min_safety: SafetyLevel,
     ) -> RpcResult<()>;
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -10,6 +10,15 @@
 extern crate alloc;
 
 mod api;
+#[cfg(feature = "client")]
+pub use api::{
+    EngineApiExtClient, MinerApiExtClient, OpAdminApiClient, OpP2PApiClient, RollupNodeClient,
+    SupervisorApiClient,
+};
+pub use api::{
+    EngineApiExtServer, MinerApiExtServer, OpAdminApiServer, OpP2PApiServer, RollupNodeServer,
+    SupervisorApiServer,
+};
 
 mod js_types;
 pub use js_types::{


### PR DESCRIPTION
Exports `RPC` APIs from `maili-rpc` crate root