### PR TITLE
fix(docs): Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ OP Stack unique types and interfaces.
 The following crates are provided by `maili`.
 
 - ![maili](https://img.shields.io/crates/v/maili?label=maili)
-- ![maili-rpc](https://img.shields.io/crates/v/maili-rpc?label=maili-rpc)
 - ![maili-consensus](https://img.shields.io/crates/v/maili-consensus?label=maili-consensus)
 - ![maili-genesis](https://img.shields.io/crates/v/maili-genesis?label=maili-genesis)
 - ![maili-protocol](https://img.shields.io/crates/v/maili-protocol?label=maili-protocol)
 - ![maili-registry](https://img.shields.io/crates/v/maili-registry?label=maili-registry)
+- ![maili-rpc](https://img.shields.io/crates/v/maili-rpc?label=maili-rpc)
 
 
 ## Development Status
@@ -53,10 +53,10 @@ maili is intended to be `no_std` compatible, initially for use in [kona][kona].
 The following crates support `no_std`.
 Notice, provider crates do not support `no_std` compatibility.
 
-- [`maili-protocol`][maili-protocol]
-- [`maili-registry`][maili-registry] (note: requires `serde`)
 - [`maili-consensus`][maili-consensus]
 - [`maili-genesis`][maili-genesis]
+- [`maili-protocol`][maili-protocol]
+- [`maili-registry`][maili-registry] (note: requires `serde`)
 - [`maili-rpc`][maili-rpc]
 
 If you would like to add no_std support to a crate,

--- a/README.md
+++ b/README.md
@@ -84,10 +84,12 @@ shall be dual licensed as above, without any additional terms or conditions.
 
 [check-no-std]: ./scripts/check_no_std.sh
 
-[kona]: https://github.com/anton-rs/kona
+[kona]: https://github.com/op-rs/kona
 [op-alloy]: https://github.com/alloy-rs/op-alloy
 [contributing]: https://op-rs.github.io/maili
 
 [maili-protocol]: https://crates.io/crates/maili-protocol
 [maili-registry]: https://crates.io/crates/maili-registry
 [maili-consensus]: https://crates.io/crates/maili-consensus
+[maili-genesis]: https://crates.io/crates/maili-genesis
+[maili-rpc]: https://crates.io/crates/maili-rpc

--- a/book/src/links.md
+++ b/book/src/links.md
@@ -58,7 +58,7 @@
 
 [revm]: https://github.com/bluealloy/revm
 [2718]: https://eips.ethereum.org/EIPS/eip-2718
-[cannon-rs]: https://github.com/anton-rs/cannon-rs
+[cannon-rs]: https://github.com/op-rs/cannon-rs
 [asterisc]: https://github.com/ethereum-optimism/asterisc
 [op-stack]: https://github.com/ethereum-optimism/optimism
 [op-succinct]: https://github.com/succinctlabs/op-succinct
@@ -74,11 +74,11 @@
 
 <!-- Kona links -->
 
-[kona]: https://github.com/anton-rs/kona
-[book]: https://anton-rs.github.io/kona/
-[issues]: https://github.com/anton-rs/kona/issues
-[new-issue]: https://github.com/anton-rs/kona/issues/new
-[contributing]: https://github.com/anton-rs/kona/tree/main/CONTRIBUTING.md
+[kona]: https://github.com/op-rs/kona
+[book]: https://op-rs.github.io/kona/
+[issues]: https://github.com/op-rs/kona/issues
+[new-issue]: https://github.com/op-rs/kona/issues/new
+[contributing]: https://github.com/op-rs/kona/tree/main/CONTRIBUTING.md
 
 <!-- People -->
 

--- a/crates/genesis/README.md
+++ b/crates/genesis/README.md
@@ -28,4 +28,4 @@ maili-genesis = { version = "x.y.z", default-features = false, features = ["serd
 <!-- Links -->
 
 [alloy-genesis]: https://github.com/alloy-rs
-[kona]: https://github.com/anton-rs/kona/blob/main/Cargo.toml#L137
+[kona]: https://github.com/op-rs/kona/blob/main/Cargo.toml#L137

--- a/crates/maili/README.md
+++ b/crates/maili/README.md
@@ -79,7 +79,7 @@ shall be dual licensed as above, without any additional terms or conditions.
 
 [check-no-std]: https://github.com/op-rs/maili/blob/main/scripts/check_no_std.sh
 
-[kona]: https://github.com/anton-rs/kona
+[kona]: https://github.com/op-rs/kona
 [alloy]: https://github.com/alloy-rs/alloy
 [contributing]: https://op-rs.github.io/maili
 


### PR DESCRIPTION
Fixes broken readme links and updates links pointing to `anton-rs` to point to `op-rs`