### PR TITLE
feat(protocol): `L1BlockInfoInterop`

### DIFF
--- a/crates/protocol/src/info/interop.rs
+++ b/crates/protocol/src/info/interop.rs
@@ -67,8 +67,6 @@ impl L1BlockInfoInterop {
         buf.extend_from_slice(U256::from(self.blob_base_fee).to_be_bytes::<32>().as_ref());
         buf.extend_from_slice(self.block_hash.as_ref());
         buf.extend_from_slice(self.batcher_address.into_word().as_ref());
-        // Notice: do not include the `empty_scalars` field in the calldata.
-        // Notice: do not include the `l1_fee_overhead` field in the calldata.
         buf.into()
     }
 

--- a/crates/protocol/src/info/interop.rs
+++ b/crates/protocol/src/info/interop.rs
@@ -1,12 +1,12 @@
-//! Contains ecotone-specific L1 block info types.
+//! Contains interop-specific L1 block info types.
 
 use crate::DecodeError;
 use alloc::{format, string::ToString, vec::Vec};
 use alloy_primitives::{Address, Bytes, B256, U256};
 
-/// Represents the fields within an Ecotone L1 block info transaction.
+/// Represents the fields within an Interop L1 block info transaction.
 ///
-/// Ecotone Binary Format
+/// Interop Binary Format
 /// +---------+--------------------------+
 /// | Bytes   | Field                    |
 /// +---------+--------------------------+
@@ -23,7 +23,7 @@ use alloy_primitives::{Address, Bytes, B256, U256};
 /// +---------+--------------------------+
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Default, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct L1BlockInfoEcotone {
+pub struct L1BlockInfoInterop {
     /// The current L1 origin block number
     pub number: u64,
     /// The current L1 origin block's timestamp
@@ -42,28 +42,19 @@ pub struct L1BlockInfoEcotone {
     pub blob_base_fee_scalar: u32,
     /// The fee scalar for L1 data
     pub base_fee_scalar: u32,
-    /// Indicates that the scalars are empty.
-    /// This is an edge case where the first block in ecotone has no scalars,
-    /// so the bedrock tx l1 cost function needs to be used.
-    pub empty_scalars: bool,
-    /// The l1 fee overhead used along with the `empty_scalars` field for the
-    /// bedrock tx l1 cost function.
-    ///
-    /// This field is deprecated in the Ecotone Hardfork.
-    pub l1_fee_overhead: U256,
 }
 
-impl L1BlockInfoEcotone {
-    /// The type byte identifier for the L1 scalar format in Ecotone.
+impl L1BlockInfoInterop {
+    /// The type byte identifier for the L1 scalar format in Interop.
     pub const L1_SCALAR: u8 = 1;
 
-    /// The length of an L1 info transaction in Ecotone.
+    /// The length of an L1 info transaction in Interop.
     pub const L1_INFO_TX_LEN: usize = 4 + 32 * 5;
 
-    /// The 4 byte selector of "setL1BlockValuesEcotone()"
-    pub const L1_INFO_TX_SELECTOR: [u8; 4] = [0x44, 0x0a, 0x5e, 0x20];
+    /// The 4 byte selector of "setL1BlockValuesInterop()"
+    pub const L1_INFO_TX_SELECTOR: [u8; 4] = [0x76, 0x0e, 0xe0, 0x4d];
 
-    /// Encodes the [L1BlockInfoEcotone] object into Ethereum transaction calldata.
+    /// Encodes the [L1BlockInfoInterop] object into Ethereum transaction calldata.
     pub fn encode_calldata(&self) -> Bytes {
         let mut buf = Vec::with_capacity(Self::L1_INFO_TX_LEN);
         buf.extend_from_slice(Self::L1_INFO_TX_SELECTOR.as_ref());
@@ -81,11 +72,11 @@ impl L1BlockInfoEcotone {
         buf.into()
     }
 
-    /// Decodes the [L1BlockInfoEcotone] object from ethereum transaction calldata.
+    /// Decodes the [L1BlockInfoInterop] object from ethereum transaction calldata.
     pub fn decode_calldata(r: &[u8]) -> Result<Self, DecodeError> {
         if r.len() != Self::L1_INFO_TX_LEN {
             return Err(DecodeError::InvalidLength(format!(
-                "Invalid calldata length for Ecotone L1 info transaction, expected {}, got {}",
+                "Invalid calldata length for Interop L1 info transaction, expected {}, got {}",
                 Self::L1_INFO_TX_LEN,
                 r.len()
             )));
@@ -126,12 +117,6 @@ impl L1BlockInfoEcotone {
             blob_base_fee,
             blob_base_fee_scalar,
             base_fee_scalar,
-            // Notice: the `empty_scalars` field is not included in the calldata.
-            // This is used by the evm to indicate that the bedrock tx l1 cost function
-            // needs to be used.
-            empty_scalars: false,
-            // Notice: the `l1_fee_overhead` field is not included in the calldata.
-            l1_fee_overhead: U256::ZERO,
         })
     }
 }

--- a/crates/protocol/src/info/mod.rs
+++ b/crates/protocol/src/info/mod.rs
@@ -9,5 +9,8 @@ pub use bedrock::L1BlockInfoBedrock;
 mod ecotone;
 pub use ecotone::L1BlockInfoEcotone;
 
+mod interop;
+pub use interop::L1BlockInfoInterop;
+
 mod errors;
 pub use errors::{BlockInfoError, DecodeError};

--- a/crates/protocol/src/info/variant.rs
+++ b/crates/protocol/src/info/variant.rs
@@ -13,6 +13,8 @@ use crate::{
     L1InfoDepositSource,
 };
 
+use super::L1BlockInfoInterop;
+
 /// The system transaction gas limit post-Regolith
 const REGOLITH_SYSTEM_TX_GAS: u64 = 1_000_000;
 
@@ -34,6 +36,8 @@ pub enum L1BlockInfoTx {
     Bedrock(L1BlockInfoBedrock),
     /// An Ecotone L1 info transaction
     Ecotone(L1BlockInfoEcotone),
+    /// An Interop L1 info transaction
+    Interop(L1BlockInfoInterop),
 }
 
 impl L1BlockInfoTx {
@@ -65,19 +69,36 @@ impl L1BlockInfoTx {
             let base_fee_scalar = u32::from_be_bytes(
                 scalar[28..32].try_into().map_err(|_| BlockInfoError::BaseFeeScalar)?,
             );
-            Ok(Self::Ecotone(L1BlockInfoEcotone {
-                number: l1_header.number,
-                time: l1_header.timestamp,
-                base_fee: l1_header.base_fee_per_gas.unwrap_or(0),
-                block_hash: l1_header.hash_slow(),
-                sequence_number,
-                batcher_address: system_config.batcher_address,
-                blob_base_fee: l1_header.blob_fee(BlobParams::cancun()).unwrap_or(1),
-                blob_base_fee_scalar,
-                base_fee_scalar,
-                empty_scalars: false,
-                l1_fee_overhead: U256::ZERO,
-            }))
+
+            if rollup_config.is_interop_active(l2_block_time)
+                && rollup_config.interop_time.unwrap_or_default() != l2_block_time
+            {
+                Ok(Self::Interop(L1BlockInfoInterop {
+                    number: l1_header.number,
+                    time: l1_header.timestamp,
+                    base_fee: l1_header.base_fee_per_gas.unwrap_or(0),
+                    block_hash: l1_header.hash_slow(),
+                    sequence_number,
+                    batcher_address: system_config.batcher_address,
+                    blob_base_fee: l1_header.blob_fee(BlobParams::cancun()).unwrap_or(1),
+                    blob_base_fee_scalar,
+                    base_fee_scalar,
+                }))
+            } else {
+                Ok(Self::Ecotone(L1BlockInfoEcotone {
+                    number: l1_header.number,
+                    time: l1_header.timestamp,
+                    base_fee: l1_header.base_fee_per_gas.unwrap_or(0),
+                    block_hash: l1_header.hash_slow(),
+                    sequence_number,
+                    batcher_address: system_config.batcher_address,
+                    blob_base_fee: l1_header.blob_fee(BlobParams::cancun()).unwrap_or(1),
+                    blob_base_fee_scalar,
+                    base_fee_scalar,
+                    empty_scalars: false,
+                    l1_fee_overhead: U256::ZERO,
+                }))
+            }
         } else {
             Ok(Self::Bedrock(L1BlockInfoBedrock {
                 number: l1_header.number,
@@ -147,6 +168,9 @@ impl L1BlockInfoTx {
             L1BlockInfoEcotone::L1_INFO_TX_SELECTOR => L1BlockInfoEcotone::decode_calldata(r)
                 .map(Self::Ecotone)
                 .map_err(|e| DecodeError::ParseError(format!("Ecotone decode error: {}", e))),
+            L1BlockInfoInterop::L1_INFO_TX_SELECTOR => L1BlockInfoInterop::decode_calldata(r)
+                .map(Self::Interop)
+                .map_err(|e| DecodeError::ParseError(format!("Interop decode error: {}", e))),
             _ => Err(DecodeError::InvalidSelector),
         }
     }
@@ -154,7 +178,7 @@ impl L1BlockInfoTx {
     /// Returns whether the scalars are empty.
     pub const fn empty_scalars(&self) -> bool {
         match self {
-            Self::Bedrock(_) => false,
+            Self::Bedrock(_) | Self::Interop(_) => false,
             Self::Ecotone(L1BlockInfoEcotone { empty_scalars, .. }) => *empty_scalars,
         }
     }
@@ -164,6 +188,7 @@ impl L1BlockInfoTx {
         match self {
             Self::Bedrock(ref tx) => tx.block_hash,
             Self::Ecotone(ref tx) => tx.block_hash,
+            Self::Interop(ref tx) => tx.block_hash,
         }
     }
 
@@ -172,16 +197,16 @@ impl L1BlockInfoTx {
         match self {
             Self::Bedrock(bedrock_tx) => bedrock_tx.encode_calldata(),
             Self::Ecotone(ecotone_tx) => ecotone_tx.encode_calldata(),
+            Self::Interop(interop_tx) => interop_tx.encode_calldata(),
         }
     }
 
     /// Returns the L1 [BlockNumHash] for the info transaction.
     pub const fn id(&self) -> BlockNumHash {
         match self {
-            Self::Ecotone(L1BlockInfoEcotone { number, block_hash, .. }) => {
-                BlockNumHash { number: *number, hash: *block_hash }
-            }
-            Self::Bedrock(L1BlockInfoBedrock { number, block_hash, .. }) => {
+            Self::Ecotone(L1BlockInfoEcotone { number, block_hash, .. })
+            | Self::Bedrock(L1BlockInfoBedrock { number, block_hash, .. })
+            | Self::Interop(L1BlockInfoInterop { number, block_hash, .. }) => {
                 BlockNumHash { number: *number, hash: *block_hash }
             }
         }
@@ -190,8 +215,9 @@ impl L1BlockInfoTx {
     /// Returns the l1 base fee.
     pub fn l1_base_fee(&self) -> U256 {
         match self {
-            Self::Bedrock(L1BlockInfoBedrock { base_fee, .. }) => U256::from(*base_fee),
-            Self::Ecotone(L1BlockInfoEcotone { base_fee, .. }) => U256::from(*base_fee),
+            Self::Bedrock(L1BlockInfoBedrock { base_fee, .. })
+            | Self::Ecotone(L1BlockInfoEcotone { base_fee, .. })
+            | Self::Interop(L1BlockInfoInterop { base_fee, .. }) => U256::from(*base_fee),
         }
     }
 
@@ -199,7 +225,8 @@ impl L1BlockInfoTx {
     pub fn l1_fee_scalar(&self) -> U256 {
         match self {
             Self::Bedrock(L1BlockInfoBedrock { l1_fee_scalar, .. }) => *l1_fee_scalar,
-            Self::Ecotone(L1BlockInfoEcotone { base_fee_scalar, .. }) => {
+            Self::Ecotone(L1BlockInfoEcotone { base_fee_scalar, .. })
+            | Self::Interop(L1BlockInfoInterop { base_fee_scalar, .. }) => {
                 U256::from(*base_fee_scalar)
             }
         }
@@ -209,7 +236,8 @@ impl L1BlockInfoTx {
     pub fn blob_base_fee(&self) -> U256 {
         match self {
             Self::Bedrock(_) => U256::ZERO,
-            Self::Ecotone(L1BlockInfoEcotone { blob_base_fee, .. }) => U256::from(*blob_base_fee),
+            Self::Ecotone(L1BlockInfoEcotone { blob_base_fee, .. })
+            | Self::Interop(L1BlockInfoInterop { blob_base_fee, .. }) => U256::from(*blob_base_fee),
         }
     }
 
@@ -217,7 +245,8 @@ impl L1BlockInfoTx {
     pub fn blob_base_fee_scalar(&self) -> U256 {
         match self {
             Self::Bedrock(_) => U256::ZERO,
-            Self::Ecotone(L1BlockInfoEcotone { blob_base_fee_scalar, .. }) => {
+            Self::Ecotone(L1BlockInfoEcotone { blob_base_fee_scalar, .. })
+            | Self::Interop(L1BlockInfoInterop { blob_base_fee_scalar, .. }) => {
                 U256::from(*blob_base_fee_scalar)
             }
         }
@@ -228,22 +257,25 @@ impl L1BlockInfoTx {
         match self {
             Self::Bedrock(L1BlockInfoBedrock { l1_fee_overhead, .. }) => *l1_fee_overhead,
             Self::Ecotone(L1BlockInfoEcotone { l1_fee_overhead, .. }) => *l1_fee_overhead,
+            Self::Interop(_) => U256::ZERO,
         }
     }
 
     /// Returns the batcher address for the info transaction
     pub const fn batcher_address(&self) -> Address {
         match self {
-            Self::Bedrock(L1BlockInfoBedrock { batcher_address, .. }) => *batcher_address,
-            Self::Ecotone(L1BlockInfoEcotone { batcher_address, .. }) => *batcher_address,
+            Self::Bedrock(L1BlockInfoBedrock { batcher_address, .. })
+            | Self::Ecotone(L1BlockInfoEcotone { batcher_address, .. })
+            | Self::Interop(L1BlockInfoInterop { batcher_address, .. }) => *batcher_address,
         }
     }
 
     /// Returns the sequence number for the info transaction
     pub const fn sequence_number(&self) -> u64 {
         match self {
-            Self::Bedrock(L1BlockInfoBedrock { sequence_number, .. }) => *sequence_number,
-            Self::Ecotone(L1BlockInfoEcotone { sequence_number, .. }) => *sequence_number,
+            Self::Bedrock(L1BlockInfoBedrock { sequence_number, .. })
+            | Self::Ecotone(L1BlockInfoEcotone { sequence_number, .. })
+            | Self::Interop(L1BlockInfoInterop { sequence_number, .. }) => *sequence_number,
         }
     }
 }
@@ -256,6 +288,7 @@ mod test {
 
     const RAW_BEDROCK_INFO_TX: [u8; L1BlockInfoBedrock::L1_INFO_TX_LEN] = hex!("015d8eb9000000000000000000000000000000000000000000000000000000000117c4eb0000000000000000000000000000000000000000000000000000000065280377000000000000000000000000000000000000000000000000000000026d05d953392012032675be9f94aae5ab442de73c5f4fb1bf30fa7dd0d2442239899a40fc00000000000000000000000000000000000000000000000000000000000000040000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f3298500000000000000000000000000000000000000000000000000000000000000bc00000000000000000000000000000000000000000000000000000000000a6fe0");
     const RAW_ECOTONE_INFO_TX: [u8; L1BlockInfoEcotone::L1_INFO_TX_LEN] = hex!("440a5e2000000558000c5fc5000000000000000500000000661c277300000000012bec20000000000000000000000000000000000000000000000000000000026e9f109900000000000000000000000000000000000000000000000000000000000000011c4c84c50740386c7dc081efddd644405f04cde73e30a2e381737acce9f5add30000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985");
+    const RAW_INTEROP_INFO_TX: [u8; L1BlockInfoInterop::L1_INFO_TX_LEN] = hex!("760ee04d00000558000c5fc50000000000000001000000006789ab380000000000000000000000000000000000000000000000000000000000000000000000003b9aca0000000000000000000000000000000000000000000000000000000000000000014f98b83baf52c498b49bfff33e59965b27da7febbea9a2fcc4719d06dc06932a000000000000000000000000c0658ee336b551ff83216fbdf85ec92613d23602");
 
     #[test]
     fn bedrock_l1_block_info_invalid_len() {
@@ -274,6 +307,16 @@ mod test {
         assert_eq!(
             err.err().unwrap().to_string(),
             "Invalid data length: Invalid calldata length for Ecotone L1 info transaction, expected 164, got 2"
+        );
+    }
+
+    #[test]
+    fn interop_l1_block_info_invalid_len() {
+        let err = L1BlockInfoInterop::decode_calldata(&[0xde, 0xad]);
+        assert!(err.is_err());
+        assert_eq!(
+            err.err().unwrap().to_string(),
+            "Invalid data length: Invalid calldata length for Interop L1 info transaction, expected 164, got 2"
         );
     }
 
@@ -302,6 +345,18 @@ mod test {
     }
 
     #[test]
+    fn test_l1_block_info_tx_block_hash_interop() {
+        let interop = L1BlockInfoTx::Interop(L1BlockInfoInterop {
+            block_hash: b256!("1c4c84c50740386c7dc081efddd644405f04cde73e30a2e381737acce9f5add3"),
+            ..Default::default()
+        });
+        assert_eq!(
+            interop.block_hash(),
+            b256!("1c4c84c50740386c7dc081efddd644405f04cde73e30a2e381737acce9f5add3")
+        );
+    }
+
+    #[test]
     fn test_l1_base_fee() {
         let bedrock =
             L1BlockInfoTx::Bedrock(L1BlockInfoBedrock { base_fee: 123, ..Default::default() });
@@ -310,6 +365,10 @@ mod test {
         let ecotone =
             L1BlockInfoTx::Ecotone(L1BlockInfoEcotone { base_fee: 456, ..Default::default() });
         assert_eq!(ecotone.l1_base_fee(), U256::from(456));
+
+        let interop =
+            L1BlockInfoTx::Interop(L1BlockInfoInterop { base_fee: 789, ..Default::default() });
+        assert_eq!(interop.l1_base_fee(), U256::from(789));
     }
 
     #[test]
@@ -325,6 +384,9 @@ mod test {
             ..Default::default()
         });
         assert_eq!(ecotone.l1_fee_overhead(), U256::from(456));
+
+        let interop = L1BlockInfoTx::Interop(L1BlockInfoInterop::default());
+        assert_eq!(interop.l1_fee_overhead(), U256::ZERO);
     }
 
     #[test]
@@ -340,6 +402,12 @@ mod test {
             ..Default::default()
         });
         assert_eq!(ecotone.l1_fee_scalar(), U256::from(456));
+
+        let interop = L1BlockInfoTx::Interop(L1BlockInfoInterop {
+            base_fee_scalar: 789,
+            ..Default::default()
+        });
+        assert_eq!(interop.l1_fee_scalar(), U256::from(789));
     }
 
     #[test]
@@ -350,6 +418,10 @@ mod test {
         let ecotone =
             L1BlockInfoTx::Ecotone(L1BlockInfoEcotone { blob_base_fee: 456, ..Default::default() });
         assert_eq!(ecotone.blob_base_fee(), U256::from(456));
+
+        let interop =
+            L1BlockInfoTx::Interop(L1BlockInfoInterop { blob_base_fee: 789, ..Default::default() });
+        assert_eq!(interop.blob_base_fee(), U256::from(789));
     }
 
     #[test]
@@ -362,6 +434,12 @@ mod test {
             ..Default::default()
         });
         assert_eq!(ecotone.blob_base_fee_scalar(), U256::from(456));
+
+        let interop = L1BlockInfoTx::Interop(L1BlockInfoInterop {
+            blob_base_fee_scalar: 789,
+            ..Default::default()
+        });
+        assert_eq!(interop.blob_base_fee_scalar(), U256::from(789));
     }
 
     #[test]
@@ -427,6 +505,29 @@ mod test {
     }
 
     #[test]
+    fn interop_l1_block_info_tx_roundtrip() {
+        let expected = L1BlockInfoInterop {
+            number: 0,
+            time: 1737075512,
+            base_fee: 1000000000,
+            block_hash: b256!("4f98b83baf52c498b49bfff33e59965b27da7febbea9a2fcc4719d06dc06932a"),
+            sequence_number: 1,
+            batcher_address: address!("c0658ee336b551ff83216fbdf85ec92613d23602"),
+            blob_base_fee: 1,
+            blob_base_fee_scalar: 810949,
+            base_fee_scalar: 1368,
+        };
+
+        let L1BlockInfoTx::Interop(decoded) =
+            L1BlockInfoTx::decode_calldata(RAW_INTEROP_INFO_TX.as_ref()).unwrap()
+        else {
+            panic!("Wrong fork");
+        };
+        assert_eq!(expected, decoded);
+        assert_eq!(decoded.encode_calldata().as_ref(), RAW_INTEROP_INFO_TX);
+    }
+
+    #[test]
     fn try_new_with_deposit_tx_bedrock() {
         let rollup_config = RollupConfig::default();
         let system_config = SystemConfig::default();
@@ -488,6 +589,49 @@ mod test {
 
         let scalar = system_config.scalar.to_be_bytes::<32>();
         let blob_base_fee_scalar = (scalar[0] == L1BlockInfoEcotone::L1_SCALAR)
+            .then(|| {
+                u32::from_be_bytes(
+                    scalar[24..28].try_into().expect("Failed to parse L1 blob base fee scalar"),
+                )
+            })
+            .unwrap_or_default();
+        let base_fee_scalar =
+            u32::from_be_bytes(scalar[28..32].try_into().expect("Failed to parse base fee scalar"));
+        assert_eq!(l1_info.blob_base_fee_scalar, blob_base_fee_scalar);
+        assert_eq!(l1_info.base_fee_scalar, base_fee_scalar);
+    }
+
+    #[test]
+    fn try_new_with_deposit_tx_interop() {
+        let rollup_config = RollupConfig { interop_time: Some(1), ..Default::default() };
+        let system_config = SystemConfig::default();
+        let sequence_number = 0;
+        let l1_header = Header::default();
+        let l2_block_time = 0xFF;
+
+        let l1_info = L1BlockInfoTx::try_new(
+            &rollup_config,
+            &system_config,
+            sequence_number,
+            &l1_header,
+            l2_block_time,
+        )
+        .unwrap();
+
+        let L1BlockInfoTx::Interop(l1_info) = l1_info else {
+            panic!("Wrong fork");
+        };
+
+        assert_eq!(l1_info.number, l1_header.number);
+        assert_eq!(l1_info.time, l1_header.timestamp);
+        assert_eq!(l1_info.base_fee, { l1_header.base_fee_per_gas.unwrap_or(0) });
+        assert_eq!(l1_info.block_hash, l1_header.hash_slow());
+        assert_eq!(l1_info.sequence_number, sequence_number);
+        assert_eq!(l1_info.batcher_address, system_config.batcher_address);
+        assert_eq!(l1_info.blob_base_fee, l1_header.blob_fee(BlobParams::cancun()).unwrap_or(1));
+
+        let scalar = system_config.scalar.to_be_bytes::<32>();
+        let blob_base_fee_scalar = (scalar[0] == L1BlockInfoInterop::L1_SCALAR)
             .then(|| {
                 u32::from_be_bytes(
                     scalar[24..28].try_into().expect("Failed to parse L1 blob base fee scalar"),

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -68,7 +68,8 @@ pub use deposits::{
 
 mod info;
 pub use info::{
-    BlockInfoError, DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx,
+    BlockInfoError, DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoInterop,
+    L1BlockInfoTx,
 };
 
 mod fee;

--- a/crates/protocol/src/utils.rs
+++ b/crates/protocol/src/utils.rs
@@ -8,8 +8,8 @@ use maili_consensus::DepositTxEnvelope;
 use maili_genesis::{RollupConfig, SystemConfig};
 
 use crate::{
-    L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx, OpBlockConversionError, SpanBatchError,
-    SpanDecodingError,
+    info::L1BlockInfoInterop, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoTx,
+    OpBlockConversionError, SpanBatchError, SpanDecodingError,
 };
 
 /// Returns if the given `value` is a deposit transaction.
@@ -52,6 +52,11 @@ where
     let l1_fee_scalar = match l1_info {
         L1BlockInfoTx::Bedrock(L1BlockInfoBedrock { l1_fee_scalar, .. }) => l1_fee_scalar,
         L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
+            base_fee_scalar,
+            blob_base_fee_scalar,
+            ..
+        })
+        | L1BlockInfoTx::Interop(L1BlockInfoInterop {
             base_fee_scalar,
             blob_base_fee_scalar,
             ..


### PR DESCRIPTION
## Overview

Adds the new `L1BlockInfo` transaction variant for the Interop hardfork, as not specified (😠) but implemented in the `op-node`: https://github.com/ethereum-optimism/optimism/blob/a51637c0bb42a2a5f579d0b0ac7a8975f4d47dc5/op-node/rollup/derive/l1_block_info.go#L4