### PR TITLE
feat(protocol): Deposit context closing tx formation

### DIFF
--- a/crates/protocol/src/deposits.rs
+++ b/crates/protocol/src/deposits.rs
@@ -78,6 +78,8 @@ pub enum DepositSourceDomainIdentifier {
     L1Info = 1,
     /// An upgrade deposit source.
     Upgrade = 2,
+    /// Deposit context closing transaction.
+    DepositContext = 3,
 }
 
 /// Source domains for deposit transactions.
@@ -89,6 +91,8 @@ pub enum DepositSourceDomain {
     L1Info(L1InfoDepositSource),
     /// An upgrade deposit source.
     Upgrade(UpgradeDepositSource),
+    /// A deposit context closing source
+    DepositContext(DepositContextDepositSource),
 }
 
 impl DepositSourceDomain {
@@ -98,6 +102,7 @@ impl DepositSourceDomain {
             Self::User(ds) => ds.source_hash(),
             Self::L1Info(ds) => ds.source_hash(),
             Self::Upgrade(ds) => ds.source_hash(),
+            Self::DepositContext(ds) => ds.source_hash(),
         }
     }
 }
@@ -188,6 +193,36 @@ impl UpgradeDepositSource {
             (DepositSourceDomainIdentifier::Upgrade as u64).to_be_bytes();
         domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
         domain_input[32..].copy_from_slice(&intent_hash[..]);
+        keccak256(domain_input)
+    }
+}
+
+/// A deposit context transaction source.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+pub struct DepositContextDepositSource {
+    /// The L1 block hash.
+    pub l1_block_hash: B256,
+    /// The sequence number.
+    pub seq_number: u64,
+}
+
+impl DepositContextDepositSource {
+    /// Creates a new [L1InfoDepositSource].
+    pub const fn new(l1_block_hash: B256, seq_number: u64) -> Self {
+        Self { l1_block_hash, seq_number }
+    }
+
+    /// Returns the source hash.
+    pub fn source_hash(&self) -> B256 {
+        let mut input = [0u8; 32 * 2];
+        input[..32].copy_from_slice(&self.l1_block_hash[..]);
+        input[32 * 2 - 8..].copy_from_slice(&self.seq_number.to_be_bytes());
+        let deposit_id_hash = keccak256(input);
+        let mut domain_input = [0u8; 32 * 2];
+        let identifier_bytes: [u8; 8] =
+            (DepositSourceDomainIdentifier::DepositContext as u64).to_be_bytes();
+        domain_input[32 - 8..32].copy_from_slice(&identifier_bytes);
+        domain_input[32..].copy_from_slice(&deposit_id_hash[..]);
         keccak256(domain_input)
     }
 }

--- a/crates/protocol/src/info/deposit_context.rs
+++ b/crates/protocol/src/info/deposit_context.rs
@@ -1,0 +1,40 @@
+//! Contains the logic for creating a deposit context closing transaction for the interop hardfork.
+
+use super::L1BlockInfoTx;
+use crate::{
+    info::variant::{L1_BLOCK_ADDRESS, L1_INFO_DEPOSITOR_ADDRESS},
+    DepositContextDepositSource, DepositSourceDomain,
+};
+use alloy_consensus::Sealed;
+use alloy_primitives::{Sealable, TxKind, U256};
+use maili_consensus::TxDeposit;
+
+/// `keccak256("depositsComplete()")[4:]`
+const DEPOSIT_CONTEXT_SELECTOR: [u8; 4] = [0xe3, 0x2d, 0x20, 0xbb];
+
+/// Create a [TxDeposit] for closing the deposit context. This deposit transaction, after
+/// interop activation, always is placed last in the deposit section of the block.
+///
+/// <https://specs.optimism.io/interop/derivation.html#closing-the-deposit-context>
+pub fn closing_deposit_context_tx(
+    l1_info: &L1BlockInfoTx,
+    sequence_number: u64,
+) -> Sealed<TxDeposit> {
+    let source = DepositSourceDomain::DepositContext(DepositContextDepositSource {
+        l1_block_hash: l1_info.block_hash(),
+        seq_number: sequence_number,
+    });
+
+    let deposit_tx = TxDeposit {
+        source_hash: source.source_hash(),
+        from: L1_INFO_DEPOSITOR_ADDRESS,
+        to: TxKind::Call(L1_BLOCK_ADDRESS),
+        mint: None,
+        value: U256::ZERO,
+        gas_limit: 36_000,
+        is_system_transaction: false,
+        input: DEPOSIT_CONTEXT_SELECTOR.into(),
+    };
+
+    deposit_tx.seal_slow()
+}

--- a/crates/protocol/src/info/mod.rs
+++ b/crates/protocol/src/info/mod.rs
@@ -12,5 +12,8 @@ pub use ecotone::L1BlockInfoEcotone;
 mod interop;
 pub use interop::L1BlockInfoInterop;
 
+mod deposit_context;
+pub use deposit_context::closing_deposit_context_tx;
+
 mod errors;
 pub use errors::{BlockInfoError, DecodeError};

--- a/crates/protocol/src/info/variant.rs
+++ b/crates/protocol/src/info/variant.rs
@@ -19,10 +19,11 @@ use super::L1BlockInfoInterop;
 const REGOLITH_SYSTEM_TX_GAS: u64 = 1_000_000;
 
 /// The address of the L1 Block contract
-const L1_BLOCK_ADDRESS: Address = address!("4200000000000000000000000000000000000015");
+pub(crate) const L1_BLOCK_ADDRESS: Address = address!("4200000000000000000000000000000000000015");
 
 /// The depositor address of the L1 info transaction
-const L1_INFO_DEPOSITOR_ADDRESS: Address = address!("deaddeaddeaddeaddeaddeaddeaddeaddead0001");
+pub(crate) const L1_INFO_DEPOSITOR_ADDRESS: Address =
+    address!("deaddeaddeaddeaddeaddeaddeaddeaddead0001");
 
 /// The [L1BlockInfoTx] enum contains variants for the different versions of the L1 block info
 /// transaction on OP Stack chains.

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -61,15 +61,15 @@ pub use channel::{
 
 mod deposits;
 pub use deposits::{
-    decode_deposit, DepositError, DepositSourceDomain, DepositSourceDomainIdentifier,
-    L1InfoDepositSource, UpgradeDepositSource, UserDepositSource, DEPOSIT_EVENT_ABI,
-    DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0,
+    decode_deposit, DepositContextDepositSource, DepositError, DepositSourceDomain,
+    DepositSourceDomainIdentifier, L1InfoDepositSource, UpgradeDepositSource, UserDepositSource,
+    DEPOSIT_EVENT_ABI, DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0,
 };
 
 mod info;
 pub use info::{
-    BlockInfoError, DecodeError, L1BlockInfoBedrock, L1BlockInfoEcotone, L1BlockInfoInterop,
-    L1BlockInfoTx,
+    closing_deposit_context_tx, BlockInfoError, DecodeError, L1BlockInfoBedrock,
+    L1BlockInfoEcotone, L1BlockInfoInterop, L1BlockInfoTx,
 };
 
 mod fee;


### PR DESCRIPTION
## Overview

Adds a function for creating the new closing transaction for the deposit context, after the interop hardfork activates. This will be used by `kona-derive`'s attributes builder and placed as the final deposit transaction in payloads at + after interop activation.

spec: https://specs.optimism.io/interop/derivation.html#closing-the-deposit-context