### PR TITLE
feat(workspace): Release `0.1.6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.5](https://github.com/op-rs/maili
-/releases/tag/v0.1.5) - 2025-01-14
+## [0.1.6](https://github.com/op-rs/maili/releases/tag/v0.1.6) - 2025-01-14
 
 ### Bug Fixes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.81"
 authors = ["Alloy Contributors"]
@@ -36,12 +36,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
 # Workspace
-maili-consensus = { version = "0.1.5", path = "crates/consensus", default-features = false }
-maili-genesis = { version = "0.1.5", path = "crates/genesis", default-features = false }
-maili-protocol = { version = "0.1.5", path = "crates/protocol", default-features = false }
-maili-registry = { version = "0.1.5", path = "crates/registry", default-features = false }
-maili-rpc = { version = "0.1.5", path = "crates/rpc", default-features = false }
-maili-flz = { version = "0.1.5", path = "crates/flz", default-features = false }
+maili-consensus = { version = "0.1.6", path = "crates/consensus", default-features = false }
+maili-genesis = { version = "0.1.6", path = "crates/genesis", default-features = false }
+maili-protocol = { version = "0.1.6", path = "crates/protocol", default-features = false }
+maili-registry = { version = "0.1.6", path = "crates/registry", default-features = false }
+maili-rpc = { version = "0.1.6", path = "crates/rpc", default-features = false }
+maili-flz = { version = "0.1.6", path = "crates/flz", default-features = false }
 
 # Alloy
 alloy-eips = { version = "0.9.2", default-features = false }


### PR DESCRIPTION
## Overview

Bumps the workspace version to `0.1.6`.