### PR TITLE
chore(flz): Compression Re-exports

### DIFF
--- a/crates/flz/Cargo.toml
+++ b/crates/flz/Cargo.toml
@@ -15,8 +15,14 @@ exclude.workspace = true
 workspace = true
 
 [dependencies]
+fastlz = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 revm.workspace = true
 rstest.workspace = true
 alloy-sol-types.workspace = true
+
+[features]
+default = []
+compress = ["dep:fastlz"]
+decompress = ["dep:fastlz"]

--- a/crates/flz/src/lib.rs
+++ b/crates/flz/src/lib.rs
@@ -7,6 +7,12 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![no_std]
 
+#[cfg(feature = "compress")]
+pub use fastlz::compress;
+
+#[cfg(feature = "decompress")]
+pub use fastlz::decompress;
+
 /// Returns the length of the data after compression through FastLZ.
 ///
 /// The u32s match op-geth's Go port.

--- a/crates/flz/src/lib.rs
+++ b/crates/flz/src/lib.rs
@@ -9,7 +9,10 @@
 
 /// Returns the length of the data after compression through FastLZ.
 ///
+/// The u32s match op-geth's Go port.
+///
 /// <https://github.com/Vectorized/solady/blob/5315d937d79b335c668896d7533ac603adac5315/js/solady.js>
+/// <https://github.com/ethereum-optimism/op-geth/blob/647c346e2bef36219cc7b47d76b1cb87e7ca29e4/core/types/rollup_cost.go#L411>
 pub fn flz_compress_len(input: &[u8]) -> u32 {
     let mut idx: u32 = 2;
 


### PR DESCRIPTION
### Description

Re-exports compression and decompression from `fastlz` crate optionally.