### PR TITLE
Remove empty scalars marker and update relevant functionality

### DIFF
--- a/crates/protocol/src/info/ecotone.rs
+++ b/crates/protocol/src/info/ecotone.rs
@@ -42,10 +42,6 @@ pub struct L1BlockInfoEcotone {
     pub blob_base_fee_scalar: u32,
     /// The fee scalar for L1 data
     pub base_fee_scalar: u32,
-    /// Indicates that the scalars are empty.
-    /// This is an edge case where the first block in ecotone has no scalars,
-    /// so the bedrock tx l1 cost function needs to be used.
-    pub empty_scalars: bool,
     /// The l1 fee overhead used along with the `empty_scalars` field for the
     /// bedrock tx l1 cost function.
     ///
@@ -62,6 +58,11 @@ impl L1BlockInfoEcotone {
 
     /// The 4 byte selector of "setL1BlockValuesEcotone()"
     pub const L1_INFO_TX_SELECTOR: [u8; 4] = [0x44, 0x0a, 0x5e, 0x20];
+
+    /// Returns whether the scalars are empty.
+    pub const fn empty_scalars(&self) -> bool {
+        self.base_fee_scalar == 0 && self.blob_base_fee_scalar == 0
+    }
 
     /// Encodes the [L1BlockInfoEcotone] object into Ethereum transaction calldata.
     pub fn encode_calldata(&self) -> Bytes {
@@ -126,10 +127,6 @@ impl L1BlockInfoEcotone {
             blob_base_fee,
             blob_base_fee_scalar,
             base_fee_scalar,
-            // Notice: the `empty_scalars` field is not included in the calldata.
-            // This is used by the evm to indicate that the bedrock tx l1 cost function
-            // needs to be used.
-            empty_scalars: false,
             // Notice: the `l1_fee_overhead` field is not included in the calldata.
             l1_fee_overhead: U256::ZERO,
         })

--- a/crates/protocol/src/info/ecotone.rs
+++ b/crates/protocol/src/info/ecotone.rs
@@ -42,8 +42,10 @@ pub struct L1BlockInfoEcotone {
     pub blob_base_fee_scalar: u32,
     /// The fee scalar for L1 data
     pub base_fee_scalar: u32,
-    /// The l1 fee overhead used along with the `empty_scalars` field for the
-    /// bedrock tx l1 cost function.
+    /// The l1 fee overhead only used for bedrock fallback cost function.
+    ///
+    /// This is an edge case where the first block in ecotone has no scalars,
+    /// so the bedrock tx l1 cost function needs to be used.
     ///
     /// This field is deprecated in the Ecotone Hardfork.
     pub l1_fee_overhead: U256,

--- a/crates/protocol/src/info/variant.rs
+++ b/crates/protocol/src/info/variant.rs
@@ -175,6 +175,8 @@ impl L1BlockInfoTx {
     }
 
     /// Returns whether the scalars are empty.
+    ///
+    /// The first block of ecotone always has empty scalars.
     pub const fn empty_scalars(&self) -> bool {
         match self {
             Self::Bedrock(_) | Self::Interop(_) => false,

--- a/crates/protocol/src/info/variant.rs
+++ b/crates/protocol/src/info/variant.rs
@@ -107,7 +107,6 @@ impl L1BlockInfoTx {
                 blob_base_fee: l1_header.blob_fee(BlobParams::cancun()).unwrap_or(1),
                 blob_base_fee_scalar,
                 base_fee_scalar,
-                empty_scalars: false,
                 l1_fee_overhead: U256::ZERO,
             }))
         }
@@ -179,7 +178,7 @@ impl L1BlockInfoTx {
     pub const fn empty_scalars(&self) -> bool {
         match self {
             Self::Bedrock(_) | Self::Interop(_) => false,
-            Self::Ecotone(L1BlockInfoEcotone { empty_scalars, .. }) => *empty_scalars,
+            Self::Ecotone(ecotone) => ecotone.empty_scalars(),
         }
     }
 
@@ -444,16 +443,25 @@ mod test {
 
     #[test]
     fn test_empty_scalars() {
-        let bedrock = L1BlockInfoTx::Bedrock(L1BlockInfoBedrock { ..Default::default() });
+        let bedrock = L1BlockInfoTx::Bedrock(Default::default());
         assert!(!bedrock.empty_scalars());
 
-        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
-            empty_scalars: true,
-            ..Default::default()
-        });
+        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone::default());
         assert!(ecotone.empty_scalars());
 
-        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone::default());
+        let ecotone =
+            L1BlockInfoTx::Ecotone(L1BlockInfoEcotone { base_fee_scalar: 1, ..Default::default() });
+        assert!(!ecotone.empty_scalars());
+        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
+            blob_base_fee_scalar: 1,
+            ..Default::default()
+        });
+        assert!(!ecotone.empty_scalars());
+        let ecotone = L1BlockInfoTx::Ecotone(L1BlockInfoEcotone {
+            base_fee_scalar: 1,
+            blob_base_fee_scalar: 1,
+            ..Default::default()
+        });
         assert!(!ecotone.empty_scalars());
     }
 
@@ -491,7 +499,6 @@ mod test {
             blob_base_fee: 1,
             blob_base_fee_scalar: 810949,
             base_fee_scalar: 1368,
-            empty_scalars: false,
             l1_fee_overhead: U256::ZERO,
         };
 


### PR DESCRIPTION
Closes #53

Replaces the `L1BlockInfoEcotone::empty_scalars` bool marker with logic based on `L1BlockInfoEcotone::base_fee_scalar` and `L1BlockInfoEcotone::blob_base_fee_scalar` (those values being zero).

Changes based on previous PR: https://github.com/op-rs/maili/pull/54