### PR TITLE
Add more Span Batch unit tests

### DIFF
--- a/book/src/building/protocol/batches.md
+++ b/book/src/building/protocol/batches.md
@@ -4,7 +4,6 @@ A [Batch][batch] contains a list of transactions to be included in a specific
 L2 block. Since the [Delta hardfork][delta], there are two Batch types or
 variants: [`SingleBatch`][single-batch] and [`SpanBatch`][span-batch].
 
-
 ## Where Batches fit in the OP Stack
 
 The [Batch][batch] is the highest-level data type in the OP Stack
@@ -20,7 +19,6 @@ type contains a list of L2 transactions and is compressed into the
 into frames which are posted to the data availability layer through batcher
 transactions.
 
-
 ## Contents of a `Batch`
 
 A [`Batch`][batch] is either a [`SingleBatch`][single-batch] or a
@@ -30,6 +28,7 @@ these types are broken down in their respective sections.
 ### `SingleBatch` Type
 
 The [`SingleBatch`][single-batch] type contains the following.
+
 - A [`BlockHash`][block-hash] parent hash that represents the parent L2 block.
 - A `u64` epoch number that identifies the [epoch][epoch] for this batch.
 - A [`BlockHash`][block-hash] epoch hash.
@@ -45,6 +44,7 @@ providing the rollup config, l1 blocks, l2 safe head, and inclusion block.
 The [`SpanBatch`][span-batch] type (available since the [Delta hardfork][delta])
 comprises the data needed to build a "span" of multiple L2 blocks. It contains
 the following data.
+
 - The parent check (the first 20 bytes of the block's parent hash).
 - The l1 origin check (the first 20 bytes of the last block's l1 origin hash).
 - The genesis timestamp.
@@ -65,7 +65,6 @@ simplified to be forwards-invalidating instead of backwards-invalidating, so a n
 [`SpanBatch::check_batch_prefix`][check-batch-prefix] method provides a way to validate
 each batch as it is loaded, in an iterative fashion.
 
-
 ## Batch Encoding
 
 The first byte of the decompressed channel data is the
@@ -77,17 +76,16 @@ in the case of the [`SpanBatch`][span-batch].
 The `Batch` encoding format for the [`SingleBatch`][single-batch] is
 broken down [in the specs][specs].
 
-
 ## The `Batch` Type
 
 The [`Batch`][batch] type itself only provides two useful methods.
+
 - [`timestamp`][timestamp] returns the timestamp of the [`Batch`][batch]
-- [`deocde`][decode], constructs a new [`Batch`][batch] from the provided
+- [`decode`][decode], constructs a new [`Batch`][batch] from the provided
   raw, decompressed batch data and rollup config.
 
 Within each [`Batch`][batch] variant, the individual types contain
 more functionality.
-
 
 <!-- Links -->
 
@@ -96,22 +94,16 @@ more functionality.
 [check-batch-span]: https://docs.rs/maili-protocol/latest/maili_protocol/struct.SpanBatch.html#method.check_batch
 [span-batch-element]: https://docs.rs/maili-protocol/latest/maili_protocol/struct.SpanBatchElement.html
 [check-batch-single]: https://docs.rs/maili-protocol/latest/maili_protocol/struct.SingleBatch.html#method.check_batch
-
 [bytes]: https://docs.rs/alloy-primitives/latest/alloy_primitives/struct.Bytes.html
-
 [block-hash]: https://docs.rs/alloy-primitives/latest/alloy_primitives/aliases/type.BlockHash.html
 [epoch]: https://specs.optimism.io/glossary.html?highlight=Epoch#sequencing-epoch
-
 [decode]: https://docs.rs/maili-protocol/latest/maili_protocol/enum.Batch.html#method.decode
 [timestamp]: https://docs.rs/maili-protocol/latest/maili_protocol/enum.Batch.html#method.timestamp
-
 [specs]: https://specs.optimism.io/protocol/derivation.html#batch-format
-
 [derived]: https://docs.rs/maili-protocol/latest/maili_protocol/struct.RawSpanBatch.html#method.derive
 [batch-type]: https://docs.rs/maili-protocol/latest/maili_protocol/enum.BatchType.html
 [channel]: https://docs.rs/maili-protocol/latest/maili_protocol/struct.Channel.html
 [batch]: https://docs.rs/maili-protocol/latest/maili_protocol/enum.Batch.html
 [span-batch]: https://docs.rs/maili-protocol/latest/maili_protocol/struct.SpanBatch.html
 [single-batch]: https://docs.rs/maili-protocol/latest/maili_protocol/struct.SingleBatch.html
-
 [delta]: https://specs.optimism.io/protocol/delta/overview.html

--- a/crates/protocol/src/batch/span.rs
+++ b/crates/protocol/src/batch/span.rs
@@ -767,39 +767,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_check_batch_overlapping_blocks_l1_origin_mismatch() {
-        let trace_store: TraceStorage = Default::default();
-        let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
-
-        let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
-        let l1_blocks = vec![
-            BlockInfo { number: 10, timestamp: 20, ..Default::default() },
-            BlockInfo { number: 11, timestamp: 30, ..Default::default() },
-        ];
-        let l2_safe_head = L2BlockInfo {
-            block_info: BlockInfo { timestamp: 10, ..Default::default() },
-            l1_origin: BlockNumHash { number: 10, ..Default::default() },
-            ..Default::default()
-        };
-        let inclusion_block = BlockInfo::default();
-        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator::default();
-        let first = SpanBatchElement { epoch_num: 10, timestamp: 20, ..Default::default() };
-        let second = SpanBatchElement { epoch_num: 11, timestamp: 30, ..Default::default() };
-        let batch = SpanBatch { batches: vec![first, second], ..Default::default() };
-        //let _ =
-        //    batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await;
-        assert_eq!(
-            batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
-            BatchValidity::Drop
-        );
-        let logs = trace_store.get_by_level(Level::WARN);
-        assert_eq!(logs.len(), 1);
-        println!("{:?}", logs[0]);
-        assert!(logs[0].contains("overlapped block's L1 origin number does not match 10, 11"));
-    }
-
-    #[tokio::test]
     async fn test_check_batch_overlapping_blocks_tx_count_mismatch() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());

--- a/crates/protocol/src/batch/span.rs
+++ b/crates/protocol/src/batch/span.rs
@@ -13,7 +13,7 @@ use crate::{
     SpanBatchTransactions,
 };
 
-/// Continer of the inputs required to build a span of L2 blocks in derived form.
+/// Container of the inputs required to build a span of L2 blocks in derived form.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct SpanBatch {
     /// First 20 bytes of the first block's parent hash
@@ -108,36 +108,31 @@ impl SpanBatch {
         l1_origins: &[BlockInfo],
         l2_safe_head: L2BlockInfo,
     ) -> Result<Vec<SingleBatch>, SpanBatchError> {
+        let mut single_batches = Vec::new();
         let mut origin_index = 0;
-        let single_batches: Result<Vec<_>, _> =
-            self.batches.iter().try_fold(Vec::new(), |mut singles, batch| {
-                if batch.timestamp <= l2_safe_head.block_info.timestamp {
-                    // Skip batches that are not after the L2 safe head.
-                    Ok(singles)
-                } else {
-                    // Find the L1 origin for the batch.
-                    let origin_epoch_hash = l1_origins[origin_index..l1_origins.len()]
-                        .iter()
-                        .enumerate()
-                        .find(|(_, origin)| origin.number == batch.epoch_num)
-                        .map(|(i, origin)| {
-                            origin_index = i;
-                            origin.hash
-                        })
-                        .ok_or(SpanBatchError::MissingL1Origin)?;
-                    let single_batch = SingleBatch {
-                        epoch_num: batch.epoch_num,
-                        epoch_hash: origin_epoch_hash,
-                        timestamp: batch.timestamp,
-                        transactions: batch.transactions.clone(),
-                        ..Default::default()
-                    };
-                    // Append the new single batch.
-                    singles.push(single_batch);
-                    Ok(singles)
-                }
-            });
-        single_batches
+        for batch in &self.batches {
+            if batch.timestamp <= l2_safe_head.block_info.timestamp {
+                continue;
+            }
+            let origin_epoch_hash = l1_origins[origin_index..l1_origins.len()]
+                .iter()
+                .enumerate()
+                .find(|(_, origin)| origin.number == batch.epoch_num)
+                .map(|(i, origin)| {
+                    origin_index = i;
+                    origin.hash
+                })
+                .ok_or(SpanBatchError::MissingL1Origin)?;
+            let single_batch = SingleBatch {
+                epoch_num: batch.epoch_num,
+                epoch_hash: origin_epoch_hash,
+                timestamp: batch.timestamp,
+                transactions: batch.transactions.clone(),
+                ..Default::default()
+            };
+            single_batches.push(single_batch);
+        }
+        Ok(single_batches)
     }
 
     /// Append a [SingleBatch] to the [SpanBatch]. Updates the L1 origin check if need be.

--- a/crates/protocol/src/batch/span.rs
+++ b/crates/protocol/src/batch/span.rs
@@ -864,6 +864,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_check_batch_overlapping_blocks_tx_mismatch() {
+        let trace_store: TraceStorage = Default::default();
+        let layer = CollectingLayer::new(trace_store.clone());
+        tracing_subscriber::Registry::default().with(layer).init();
+
+        let cfg = RollupConfig {
+            delta_time: Some(0),
+            block_time: 10,
+            max_sequencer_drift: 1000,
+            ..Default::default()
+        };
+        let l1_blocks = vec![
+            BlockInfo { number: 9, timestamp: 0, ..Default::default() },
+            BlockInfo { number: 10, timestamp: 10, ..Default::default() },
+            BlockInfo { number: 11, timestamp: 20, ..Default::default() },
+        ];
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { number: 10, timestamp: 20, ..Default::default() },
+            l1_origin: BlockNumHash { number: 11, ..Default::default() },
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo::default();
+        let mut fetcher: TestBatchValidator<NoopTx> = TestBatchValidator {
+            op_blocks: vec![
+                TestOpBlock {
+                    header: Header { number: 9, ..Default::default() },
+                    body: alloy_consensus::BlockBody {
+                        transactions: vec![NoopTx],
+                        ommers: Vec::new(),
+                        withdrawals: None,
+                    },
+                },
+            ],
+            blocks: vec![
+                L2BlockInfo {
+                    block_info: BlockInfo { number: 8, timestamp: 0, ..Default::default() },
+                    l1_origin: BlockNumHash { number: 9, ..Default::default() },
+                    ..Default::default()
+                },
+                L2BlockInfo {
+                    block_info: BlockInfo { number: 9, timestamp: 10, ..Default::default() },
+                    l1_origin: BlockNumHash { number: 10, ..Default::default() },
+                    ..Default::default()
+                },
+                L2BlockInfo {
+                    block_info: BlockInfo { number: 10, timestamp: 20, ..Default::default() },
+                    l1_origin: BlockNumHash { number: 11, ..Default::default() },
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let first = SpanBatchElement {
+            epoch_num: 10,
+            timestamp: 10,
+            transactions: vec![Bytes(vec![EIP1559_TX_TYPE_ID].into())],
+        };
+        let second = SpanBatchElement { epoch_num: 10, timestamp: 60, ..Default::default() };
+        let batch = SpanBatch { batches: vec![first, second], ..Default::default() };
+        assert_eq!(
+            batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
+            BatchValidity::Drop
+        );
+        let logs = trace_store.get_by_level(Level::WARN);
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].contains("overlapped block's transaction does not match"));
+    }
+
+    #[tokio::test]
     async fn test_check_batch_block_timestamp_lt_l1_origin() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());

--- a/crates/protocol/src/batch/span.rs
+++ b/crates/protocol/src/batch/span.rs
@@ -640,6 +640,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_singular_batches_missing_l1_origin() {
+        let l1_block = BlockInfo { number: 10, timestamp: 20, ..Default::default() };
+        let l1_blocks = vec![l1_block];
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo { timestamp: 10, ..Default::default() },
+            l1_origin: BlockNumHash { number: 10, ..Default::default() },
+            ..Default::default()
+        };
+        let first = SpanBatchElement { epoch_num: 9, timestamp: 20, ..Default::default() };
+        let second = SpanBatchElement { epoch_num: 11, timestamp: 30, ..Default::default() };
+        let batch = SpanBatch { batches: vec![first, second], ..Default::default() };
+        assert_eq!(
+            batch.get_singular_batches(&l1_blocks, l2_safe_head),
+            Err(SpanBatchError::MissingL1Origin),
+        );
+    }
+
+    #[tokio::test]
     async fn test_eager_block_missing_origins() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());


### PR DESCRIPTION
Add more unit test for `SpanBatch`, namely:
- Batch block timestamp less than L1 origin
- Overlapping block tx count mismatch
- Overlapping block tx content match
- Missing L1 origin for singular batch

Closes #20
