### PR TITLE
fix(protocol): re-export op-alloy flz

### DIFF
--- a/crates/protocol/src/fee.rs
+++ b/crates/protocol/src/fee.rs
@@ -2,7 +2,9 @@
 
 use alloy_primitives::U256;
 use core::ops::Mul;
-use op_alloy_flz::flz_compress_len;
+
+/// Re-export the fastlz compression length calculation function.
+pub use op_alloy_flz::flz_compress_len;
 
 /// Cost per byte in calldata
 const ZERO_BYTE_COST: u64 = 4;

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -75,7 +75,7 @@ mod fee;
 pub use fee::{
     calculate_tx_l1_cost_bedrock, calculate_tx_l1_cost_bedrock_empty_scalars,
     calculate_tx_l1_cost_ecotone, calculate_tx_l1_cost_fjord, calculate_tx_l1_cost_regolith,
-    data_gas_bedrock, data_gas_fjord, data_gas_regolith, tx_estimated_size_fjord,
+    data_gas_bedrock, data_gas_fjord, data_gas_regolith, flz_compress_len, tx_estimated_size_fjord,
 };
 
 #[cfg(any(test, feature = "test-utils"))]


### PR DESCRIPTION
### Description

Re-exports the `op-alloy-flz` crate from `maili-protocol` since it will be used downstream in tandem with fee calculation methods.