### PR TITLE
test: cargo-dist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,3 +128,8 @@ rstest = "0.24.0"
 ## crypto
 c-kzg = { version = "1.0", default-features = false }
 k256 = { version = "0.13.4", default-features = false, features = ["ecdsa"] }
+
+# The profile that 'dist' will build with
+[profile.dist]
+inherits = "release"
+lto = "thin"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,0 +1,19 @@
+[workspace]
+members = ["cargo:."]
+
+# Config for 'dist'
+[dist]
+# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.28.0"
+# CI backends to support
+ci = "github"
+# The installers to generate for each app
+installers = ["shell"]
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+# Path that installers should place binaries in
+install-path = "CARGO_HOME"
+# Publish jobs to run in CI
+publish-jobs = []
+# Whether to install an updater program
+install-updater = false


### PR DESCRIPTION
### Description

Experimenting with `dist` to automagically publish releases with tags.