### PR TITLE
feat: implement EIP-7702 span batch support

### DIFF
--- a/crates/protocol/src/batch/mod.rs
+++ b/crates/protocol/src/batch/mod.rs
@@ -48,8 +48,7 @@ pub use single::SingleBatch;
 mod tx_data;
 pub use tx_data::{
     SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData,
-    SpanBatchLegacyTransactionData, SpanBatchTransactionData,
-    SpanBatchEip7702TransactionData
+    SpanBatchEip7702TransactionData, SpanBatchLegacyTransactionData, SpanBatchTransactionData,
 };
 
 mod traits;

--- a/crates/protocol/src/batch/mod.rs
+++ b/crates/protocol/src/batch/mod.rs
@@ -49,6 +49,7 @@ mod tx_data;
 pub use tx_data::{
     SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData,
     SpanBatchLegacyTransactionData, SpanBatchTransactionData,
+    SpanBatchEip7702TransactionData
 };
 
 mod traits;

--- a/crates/protocol/src/batch/tx_data/eip1559.rs
+++ b/crates/protocol/src/batch/tx_data/eip1559.rs
@@ -22,7 +22,7 @@ pub struct SpanBatchEip1559TransactionData {
 }
 
 impl SpanBatchEip1559TransactionData {
-    /// Converts [SpanBatchEip7702TransactionData] into a signed [`TxEip1559`].
+    /// Converts [SpanBatchEip1559TransactionData] into a signed [`TxEip1559`].
     pub fn to_signed_tx(
         &self,
         nonce: u64,

--- a/crates/protocol/src/batch/tx_data/eip7702.rs
+++ b/crates/protocol/src/batch/tx_data/eip7702.rs
@@ -1,7 +1,7 @@
 //! This module contains the eip7702 transaction data type for a span batch.
 
-use alloc::vec::Vec;
 use crate::{SpanBatchError, SpanDecodingError};
+use alloc::vec::Vec;
 use alloy_consensus::{SignableTransaction, Signed, TxEip7702};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, PrimitiveSignature as Signature, U256};

--- a/crates/protocol/src/batch/tx_data/eip7702.rs
+++ b/crates/protocol/src/batch/tx_data/eip7702.rs
@@ -68,7 +68,7 @@ mod test {
     use revm::primitives::Authorization;
 
     #[test]
-    fn encode_eip1559_tx_data_roundtrip() {
+    fn encode_eip7702_tx_data_roundtrip() {
         let authorization = Authorization {
             chain_id: U256::from(0x01),
             address: Address::left_padding_from(&[0x01, 0x02, 0x03]),
@@ -93,7 +93,7 @@ mod test {
 
         let decoded = SpanBatchTransactionData::decode(&mut encoded_buf.as_slice()).unwrap();
         let SpanBatchTransactionData::Eip7702(variable_fee_decoded) = decoded else {
-            panic!("Expected SpanBatchEip1559TransactionData, got {:?}", decoded);
+            panic!("Expected SpanBatchEip7702TransactionData, got {:?}", decoded);
         };
 
         assert_eq!(variable_fee_tx, variable_fee_decoded);

--- a/crates/protocol/src/batch/tx_data/eip7702.rs
+++ b/crates/protocol/src/batch/tx_data/eip7702.rs
@@ -2,10 +2,9 @@
 
 use crate::{SpanBatchError, SpanDecodingError};
 use alloy_consensus::{SignableTransaction, Signed, TxEip7702};
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{Address, PrimitiveSignature as Signature, U256};
 use alloy_rlp::{Bytes, RlpDecodable, RlpEncodable};
-use alloy_eips::eip7702::SignedAuthorization;
 
 /// The transaction data for an EIP-7702 transaction within a span batch.
 #[derive(Debug, Clone, PartialEq, Eq, RlpEncodable, RlpDecodable)]
@@ -83,9 +82,7 @@ mod test {
             max_priority_fee_per_gas: U256::from(0xDD),
             data: Bytes::from(alloc::vec![0x01, 0x02, 0x03]),
             access_list: AccessList::default(),
-            authorization_list: vec!(
-                arb_authorization.clone(),
-            )
+            authorization_list: vec![arb_authorization],
         };
 
         let mut encoded_buf = Vec::new();

--- a/crates/protocol/src/batch/tx_data/eip7702.rs
+++ b/crates/protocol/src/batch/tx_data/eip7702.rs
@@ -1,5 +1,6 @@
 //! This module contains the eip7702 transaction data type for a span batch.
 
+use alloc::vec::Vec;
 use crate::{SpanBatchError, SpanDecodingError};
 use alloy_consensus::{SignableTransaction, Signed, TxEip7702};
 use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};

--- a/crates/protocol/src/batch/tx_data/mod.rs
+++ b/crates/protocol/src/batch/tx_data/mod.rs
@@ -11,3 +11,6 @@ pub use eip1559::SpanBatchEip1559TransactionData;
 
 mod eip2930;
 pub use eip2930::SpanBatchEip2930TransactionData;
+
+mod eip7702;
+pub use eip7702::SpanBatchEip7702TransactionData;

--- a/crates/protocol/src/batch/tx_data/wrapper.rs
+++ b/crates/protocol/src/batch/tx_data/wrapper.rs
@@ -37,7 +37,7 @@ impl Encodable for SpanBatchTransactionData {
                 data.encode(out);
             }
             Self::Eip7702(data) => {
-                out.put_u8(TxType::Eip1559 as u8);
+                out.put_u8(TxType::Eip7702 as u8);
                 data.encode(out);
             }
         }
@@ -89,12 +89,13 @@ impl TryFrom<&TxEnvelope> for SpanBatchTransactionData {
             }
             TxEnvelope::Eip7702(s) => {
                 let s = s.tx();
-                Ok(Self::Eip1559(SpanBatchEip1559TransactionData {
+                Ok(Self::Eip7702(SpanBatchEip7702TransactionData {
                     value: s.value,
                     max_fee_per_gas: U256::from(s.max_fee_per_gas),
                     max_priority_fee_per_gas: U256::from(s.max_priority_fee_per_gas),
                     data: Bytes::from(s.input().to_vec()),
                     access_list: s.access_list.clone(),
+                    authorization_list: s.authorization_list.clone(),
                 }))
             }
             _ => Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionType)),
@@ -109,7 +110,7 @@ impl SpanBatchTransactionData {
             Self::Legacy(_) => TxType::Legacy,
             Self::Eip2930(_) => TxType::Eip2930,
             Self::Eip1559(_) => TxType::Eip1559,
-            Self::Eip7702(_) => TxType::Eip1559,
+            Self::Eip7702(_) => TxType::Eip7702,
         }
     }
 
@@ -125,6 +126,9 @@ impl SpanBatchTransactionData {
             }
             TxType::Eip1559 => {
                 Ok(Self::Eip1559(SpanBatchEip1559TransactionData::decode(&mut &b[1..])?))
+            }
+            TxType::Eip7702 => {
+                Ok(Self::Eip7702(SpanBatchEip7702TransactionData::decode(&mut &b[1..])?))
             }
             _ => Err(alloy_rlp::Error::Custom("Invalid transaction type")),
         }

--- a/crates/protocol/src/batch/tx_data/wrapper.rs
+++ b/crates/protocol/src/batch/tx_data/wrapper.rs
@@ -5,8 +5,9 @@ use alloy_primitives::{Address, PrimitiveSignature as Signature, U256};
 use alloy_rlp::{Bytes, Decodable, Encodable};
 
 use crate::{
-    SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData, SpanBatchError,
-    SpanBatchLegacyTransactionData, SpanDecodingError, SpanBatchEip7702TransactionData
+    SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData,
+    SpanBatchEip7702TransactionData, SpanBatchError, SpanBatchLegacyTransactionData,
+    SpanDecodingError,
 };
 
 /// The typed transaction data for a transaction within a span batch.
@@ -161,7 +162,9 @@ impl SpanBatchTransactionData {
             }
             Self::Eip7702(data) => {
                 let Some(addr) = to else {
-                    return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
+                    return Err(SpanBatchError::Decoding(
+                        SpanDecodingError::InvalidTransactionData,
+                    ));
                 };
                 TxEnvelope::Eip7702(data.to_signed_tx(nonce, gas, addr, chain_id, signature)?)
             }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -17,9 +17,10 @@ pub use batch::{
     Batch, BatchDecodingError, BatchEncodingError, BatchReader, BatchTransaction, BatchType,
     BatchValidationProvider, BatchValidity, BatchWithInclusionBlock, RawSpanBatch, SingleBatch,
     SpanBatch, SpanBatchBits, SpanBatchEip1559TransactionData, SpanBatchEip2930TransactionData,
-    SpanBatchElement, SpanBatchError, SpanBatchLegacyTransactionData, SpanBatchPayload,
-    SpanBatchPrefix, SpanBatchTransactionData, SpanBatchTransactions, SpanDecodingError,
-    MAX_SPAN_BATCH_ELEMENTS, SINGLE_BATCH_TYPE, SPAN_BATCH_TYPE,
+    SpanBatchEip7702TransactionData, SpanBatchElement, SpanBatchError,
+    SpanBatchLegacyTransactionData, SpanBatchPayload, SpanBatchPrefix, SpanBatchTransactionData,
+    SpanBatchTransactions, SpanDecodingError, MAX_SPAN_BATCH_ELEMENTS, SINGLE_BATCH_TYPE,
+    SPAN_BATCH_TYPE,
 };
 
 mod errors;


### PR DESCRIPTION
Adds support for serializing and deserializing EIP-7702 transactions in a span batch which will be required to implement EIP-7702 in Isthmus. Fixes #84 