### PR TITLE
fix(maili): Touchup Manifest

### DIFF
--- a/crates/maili/Cargo.toml
+++ b/crates/maili/Cargo.toml
@@ -58,6 +58,4 @@ jsonrpsee = ["maili-rpc?/jsonrpsee"]
 registry = ["dep:maili-registry"]
 protocol = ["dep:maili-protocol"]
 genesis = ["dep:maili-genesis"]
-
-# std features
 rpc = ["dep:maili-rpc"]


### PR DESCRIPTION
### Description

Small PR to touchup the `maili` crate manifest now that the split between `op-alloy` and `maili` is stable.

Closes #58