### PR TITLE
chore(registry): Pretty Missing Submodule Warnings

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -58,7 +58,7 @@ hack:
 
 # Updates the git submodule source
 source:
-  git submodule update --remote
+  @just --justfile ./crates/registry/Justfile source
 
 # Generate file bindings for super-registry
 bind:

--- a/crates/registry/Justfile
+++ b/crates/registry/Justfile
@@ -7,3 +7,7 @@ default:
 # Generate file bindings
 bind:
   cargo build
+
+# Update the `superchain-registry` git submodule source
+source:
+  git submodule update --remote --init --recursive

--- a/crates/registry/build.rs
+++ b/crates/registry/build.rs
@@ -7,6 +7,12 @@ fn main() {
     // Get the directory of this file from the environment
     let src_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
+    // Check if the `superchain-registry` directory exists
+    let superchain_registry = format!("{}/superchain-registry", src_dir);
+    if !std::path::Path::new(&superchain_registry).exists() {
+        panic!("Git Submodule missing. Please run `just source` to initialize the submodule.");
+    }
+
     // Copy the `superchain-registry/chainList.json` file to `etc/chainList.json`
     let chain_list = format!("{}/superchain-registry/chainList.json", src_dir);
     std::fs::copy(chain_list, "etc/chainList.json").unwrap();


### PR DESCRIPTION
### Description

Updates the `maili-registry` build to print a pretty warning if the scr is missing.

Fixes #152