### PR TITLE
chore(registry): Sort Superchains and Chains

### DIFF
--- a/crates/registry/build.rs
+++ b/crates/registry/build.rs
@@ -52,6 +52,15 @@ fn main() {
             superchains.superchains.push(superchain);
         }
     }
+
+    // Sort the superchains by name.
+    superchains.superchains.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // For each superchain, sort the list of chains by chain id.
+    for superchain in superchains.superchains.iter_mut() {
+        superchain.chains.sort_by(|a, b| a.chain_id.cmp(&b.chain_id));
+    }
+
     std::fs::write("etc/configs.json", serde_json::to_string_pretty(&superchains).unwrap())
         .unwrap();
 }

--- a/crates/registry/etc/configs.json
+++ b/crates/registry/etc/configs.json
@@ -1,6 +1,3822 @@
 {
   "superchains": [
     {
+      "name": "mainnet",
+      "config": {
+        "name": "Mainnet",
+        "l1": {
+          "chain_id": 1,
+          "public_rpc": "https://ethereum-rpc.publicnode.com",
+          "explorer": "https://etherscan.io"
+        },
+        "protocol_versions_addr": "0x8062abc286f5e7d9428a0ccb9abd71e50d93b935",
+        "superchain_config_addr": "0x95703e0982140d16f8eba6d158fccede42f04a4c",
+        "OPContractsManagerProxyAddr": null
+      },
+      "chains": [
+        {
+          "Name": "OP Mainnet",
+          "l2_chain_id": 10,
+          "PublicRPC": "https://mainnet.optimism.io",
+          "SequencerRPC": "https://mainnet-sequencer.optimism.io",
+          "Explorer": "https://explorer.optimism.io",
+          "SuperchainLevel": 2,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000010",
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 17422590,
+              "hash": "0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"
+            },
+            "l2": {
+              "number": 105235063,
+              "hash": "0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3"
+            },
+            "l2_time": 1686068903,
+            "system_config": {
+              "batcherAddress": "0x6887246668a3b87f54deb3b94ba47a6f63f32985",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xde1fcfb0851916ca5101820a69b13a4e276bd81f",
+            "L1CrossDomainMessengerProxy": "0x25ace71c97b33cc4729cf772ae268934f7ab5fa1",
+            "L1Erc721BridgeProxy": "0x5a7749f83b81b301cab5f48eb8516b986daef23d",
+            "L1StandardBridgeProxy": "0x99c9fc46f92e8a1c0dec1b1747d010903e884be1",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": "0x75505a97bd334e7bd3c476893285569c4136fa0f",
+            "OptimismPortalProxy": "0xbeb5fc579115071764c7423a4f12edde41f106ed",
+            "SystemConfigProxy": "0x229047fed2591dbec1ef1118d64f7af3db9eb290",
+            "ProxyAdmin": "0x543ba4aadbab8f9025686bd03993043599c6fb04",
+            "AnchorStateRegistryProxy": "0x18dac71c228d1c32c99489b7323d441e1175e443",
+            "DelayedWethProxy": "0x82511d494b5c942be57498a70fdd7184ee33b975",
+            "DisputeGameFactoryProxy": "0xe5965ab5962edc7477c8520243a95517cd252fa9",
+            "FaultDisputeGame": "0xa6f3dfdbf4855a43c529bc42ede96797252879af",
+            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
+            "PermissionedDisputeGame": "0x050ed6f6273c7d836a111e42153bc00d0380b87d",
+            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x847b5c174615b1b7fdf770882256e2d3e95b9d92",
+            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
+            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
+            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
+            "Proposer": "0x473300df21d047806a082244b417f96b32f13a33",
+            "UnsafeBlockSigner": "0xaaaa45d9549eda09e70937013520214382ffc4a2",
+            "BatchSubmitter": "0x6887246668a3b87f54deb3b94ba47a6f63f32985"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "HashKey Chain",
+          "l2_chain_id": 177,
+          "PublicRPC": "https://mainnet.hsk.xyz",
+          "SequencerRPC": "https://hashkeychain-mainnet.alt.technology",
+          "Explorer": "https://explorer.hsk.xyz",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0x0004cb44c80b6fbf8ceb1d80af688c9f7c0b2ab5",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 0,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 21414667,
+              "hash": "0x0b4540b35529055a65950aef56df1a8fe22144f453f3bbc521a1248a8edbf761"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xa96aea946b763641b616ce0c69f37e61d9cd0abd709ef13a6b833e67b76de208"
+            },
+            "l2_time": 1734347135,
+            "system_config": {
+              "batcherAddress": "0x9391791f7cb74f8bfda65edc0749efd964311b55",
+              "overhead": "0x0",
+              "scalar": "0x10000000000000000000000000000000000000000000000ffffffff01312d00",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x679a65ad62972ea3561f40a12e93cca6f79f35e6",
+            "L1CrossDomainMessengerProxy": "0x899f07862d3a03f70e07b7f01183934b485d2e97",
+            "L1Erc721BridgeProxy": "0xd4c83d93c6fae3e0804b785f9cf465be95449d04",
+            "L1StandardBridgeProxy": "0x2171e6d3b7964fa9654ce41da8a8ffaff2cc70be",
+            "L2OutputOracleProxy": "0x1c8d97e21f868f8b87fa9b16fc77d46d7b0b48a2",
+            "OptimismMintableErc20FactoryProxy": "0x0407af506d86bfa5e401099b2fc2355590638f19",
+            "OptimismPortalProxy": "0xe7aa79b59cac06f9706d896a047feb9d3bda8bd3",
+            "SystemConfigProxy": "0x43f8defe3e9286d152e91bb16a248808e7247198",
+            "ProxyAdmin": "0x7986ed289935a0f47fc434c00cde309fe2c51f1c",
+            "AnchorStateRegistryProxy": "0x4dec2aa521108d78d983c0c12656c6cf8631f2ed",
+            "DelayedWethProxy": "0xbb70d595147a141e268532bfef61a8c25054d26d",
+            "DisputeGameFactoryProxy": "0x04ec030f362ce5a0b5fe2d4b4219f287c2ebde50",
+            "FaultDisputeGame": null,
+            "Mips": "0x7447b25b91336127042cc6899b2c15668a1ab8ba",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x5b9bef4d8c36fb013c70d0a6f455807c6bd5270b"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x29fbda675fa5a07b621c2c1a6e3f874c14f612f3",
+            "ProxyAdminOwner": "0x441f31c4cdf772558d4ea31f3114de59ae145e7c",
+            "Guardian": "0xc7fcbe26c1db751d63869f72f782a56710f6be5a",
+            "Challenger": "0xfcf35cee40325db21c3dc5b45849251e78be47eb",
+            "Proposer": "0x66b8f8425ecb610239e79e3517fefddcf85af41a",
+            "UnsafeBlockSigner": "0xbc80de532cf87543aad3267cc8a4caa2813130e7",
+            "BatchSubmitter": "0x9391791f7cb74f8bfda65edc0749efd964311b55"
+          },
+          "GasPayingToken": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a"
+        },
+        {
+          "Name": "Ethernity",
+          "l2_chain_id": 183,
+          "PublicRPC": "https://mainnet.ethernitychain.io",
+          "SequencerRPC": "https://mainnet.ethernitychain.io",
+          "Explorer": "https://ernscan.io",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000183",
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x14",
+            "eip1559Denominator": "0x3e8",
+            "eip1559DenominatorCanyon": "0x3e8"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 20519340,
+              "hash": "0xbb7ad201b0ab296465865642878e9256e0fa4a3f8d06bca1f3e5c5b54be6be90"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xa5e974a6ace39285b42f92316a9e040e58f8ffc24e3aac124ff6243c28323607"
+            },
+            "l2_time": 1723547735,
+            "system_config": {
+              "batcherAddress": "0x43ca061ea80fbb4a2b5515f4be4e953b191147af",
+              "overhead": "0xbc",
+              "scalar": "0xf4240",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x464ca56d40f94e8a50efa7f5b90c59d956a0efc9",
+            "L1CrossDomainMessengerProxy": "0x226a1e4a3d8e64a9de8423f9344348c179c72cb2",
+            "L1Erc721BridgeProxy": "0x00050ae93fbfaf5823a4ae229e4651f7f7a02ffa",
+            "L1StandardBridgeProxy": "0x908c324c35ff36f64236a7cda4d50f3003e9c5c3",
+            "L2OutputOracleProxy": "0x0eb331b615030819464225ecd373e5ffbe502dc4",
+            "OptimismMintableErc20FactoryProxy": "0x45beaf3bd26b76796692b1ef1e67469b84adb914",
+            "OptimismPortalProxy": "0xda29f0b4da6c23f6c1af273945c290c0268c4ea9",
+            "SystemConfigProxy": "0x20c3035c92bdb4c461242571eeac59eed03df931",
+            "ProxyAdmin": "0x0bc380347a0b7af5453492caf20e1e38bc0abc2f",
+            "AnchorStateRegistryProxy": "0x31ee18f4dbca6a9c8599508ec70ab98cb1118e9e",
+            "DelayedWethProxy": "0xde1999df1f225d638ad3ca2c9eb5b2e52730d950",
+            "DisputeGameFactoryProxy": "0xfcdb270b674911d321f1014c347eabb1c55134fb",
+            "FaultDisputeGame": null,
+            "Mips": "0x94ce3d0b2243250d3f33df45faaeac273ca945fe",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0xa0455f010561671c640d80f51851d51318ac32ab"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
+            "ProxyAdminOwner": "0xb68361aaac2bc8a4b8bfe36b8c6d0b429b5930ea",
+            "Guardian": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
+            "Challenger": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
+            "Proposer": "0xf49212f977986347b73345d382a811e148751eed",
+            "UnsafeBlockSigner": "0xd1705b4fffc540eded73046ee1f3a8db10d143f8",
+            "BatchSubmitter": "0x43ca061ea80fbb4a2b5515f4be4e953b191147af"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Mint Mainnet",
+          "l2_chain_id": 185,
+          "PublicRPC": "https://rpc.mintchain.io",
+          "SequencerRPC": "https://rpc.mintchain.io",
+          "Explorer": "https://explorer.mintchain.io",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x4e31448a098393727b786e25b54e59dca1b77fe1",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 19861561,
+              "hash": "0x12980bfeb6e787dc906b0a6ae000733f9909f6af2121bc78a77afb5ba77988a0"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x88441835ca2344ea384e6f73e3d6f921cdd304e5bd6dca15590217e3911c61a3"
+            },
+            "l2_time": 1715608931,
+            "system_config": {
+              "batcherAddress": "0x68bdfece01535090c8f3c27ec3b1ae97e83fa4aa",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xea4165c5cdca155779803a113d8391b741ba5228",
+            "L1CrossDomainMessengerProxy": "0xf80be9f7a74ab776b69d3f0dc5c08c39b3a0ba19",
+            "L1Erc721BridgeProxy": "0xc2c908f3226d9082130d8e48378cd2efb08b521d",
+            "L1StandardBridgeProxy": "0x2b3f201543adf73160ba42e1a5b7750024f30420",
+            "L2OutputOracleProxy": "0xb751a613f2db932c6cdef5048e6d2af05f9b98ed",
+            "OptimismMintableErc20FactoryProxy": "0xf02012065ef6121a2a59ea0c590f42803cf101ea",
+            "OptimismPortalProxy": "0x59625d1fe0eeb8114a4d13c863978f39b3471781",
+            "SystemConfigProxy": "0xc975862927797812371a9fb631f83f8f5e2240d5",
+            "ProxyAdmin": "0xc684075a7cc997aa2e72152c330bdac73feacbdf",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Guardian": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Challenger": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Proposer": "0x3d53df1e69a32f98dfccf23ccb689763e21a78ba",
+            "UnsafeBlockSigner": "0x41c4fae5e80b9a622d8968bcd3ebbcf1f93b30db",
+            "BatchSubmitter": "0x68bdfece01535090c8f3c27ec3b1ae97e83fa4aa"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Swan Chain Mainnet",
+          "l2_chain_id": 254,
+          "PublicRPC": "https://mainnet-rpc.swanchain.org",
+          "SequencerRPC": "https://sequencer-mainnet.swanchain.org",
+          "Explorer": "https://swanscan.io",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000254",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": null,
+            "fjord_time": null,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 5,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 20112576,
+              "hash": "0x90dafe09640e2858bce2675c66da6b0f136215a179d49f5c9274252bd5a1f8a2"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x834c39d79eb75c4c52d745e624750b817b66eb13e483b035c42ec3aa5cfa7429"
+            },
+            "l2_time": 1718640215,
+            "system_config": {
+              "batcherAddress": "0xde794bec196832474f2f218135bfd0f7ca7fb038",
+              "overhead": "0x834",
+              "scalar": "0xf4240",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x55aec4ee11da7d655565ccc2eb3bf21a46c94e6f",
+            "L1CrossDomainMessengerProxy": "0x15567c4ffd9109795dff1d9a5233d10aef0738d2",
+            "L1Erc721BridgeProxy": "0x1ccf7e62889e6a93413deafc4e390bd4047bdc32",
+            "L1StandardBridgeProxy": "0xed7525946a09056c6aae29941b8323017382050e",
+            "L2OutputOracleProxy": "0x1c22740a0b4511e11d76434a424487862b593901",
+            "OptimismMintableErc20FactoryProxy": "0xe9614162c6128abd7790c65d711cfc43ea842153",
+            "OptimismPortalProxy": "0xba50434bc5fcc07406b1bad9ac72a4cdf776db15",
+            "SystemConfigProxy": "0x504d56cf68f791b45e3a2e895b0e1562f3431328",
+            "ProxyAdmin": "0xcc8c55ec2ea3f3001c049ec934e72b55cf52fbf3",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": "0x2069fc7097b7784fca21aa459e57e95c0046eecd",
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x3fcb6e08a960ef52ec3101a444f71a2fd964b248",
+            "ProxyAdminOwner": "0x6197f64902b9275e6815f9a5b641ed2291a5d39c",
+            "Guardian": "0x3fcb6e08a960ef52ec3101a444f71a2fd964b248",
+            "Challenger": "0x3fcb6e08a960ef52ec3101a444f71a2fd964b248",
+            "Proposer": "0xb2a5571c23d13ce16ef3e993fbe8d225d3f67366",
+            "UnsafeBlockSigner": "0x05a220507e8f4c73a446dbafc5607016a7d5eab0",
+            "BatchSubmitter": "0xde794bec196832474f2f218135bfd0f7ca7fb038"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Orderly Mainnet",
+          "l2_chain_id": 291,
+          "PublicRPC": "https://rpc.orderly.network",
+          "SequencerRPC": "https://rpc.orderly.network",
+          "Explorer": "https://explorer.orderly.network",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x08aa34cc843ceebcc88a627f18430294aa9780be",
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 18292529,
+              "hash": "0x787d5dd296d63bc6e7a4158d4f109e1260740ee115f5ed5124b35dece1fa3968"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xe53c94ddd42714239429bd132ba2fa080c7e5cc7dca816ec6e482ec0418e6d7f"
+            },
+            "l2_time": 1696608227,
+            "system_config": {
+              "batcherAddress": "0xf8db8aba597ff36ccd16fecfbb1b816b3236e9b8",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x87630a802a3789463ec4b00f89b27b1e9f6b92e9",
+            "L1CrossDomainMessengerProxy": "0xc76543a64666d9a073faef4e75f651c88e7dbc08",
+            "L1Erc721BridgeProxy": "0x934ab59ef14b638653b1c0fef7ab9a72186393dc",
+            "L1StandardBridgeProxy": "0xe07ea0436100918f157df35d01dce5c11b16d1f1",
+            "L2OutputOracleProxy": "0x5e76821c3c1abb9fd6e310224804556c61d860e0",
+            "OptimismMintableErc20FactoryProxy": "0x7a69a90d8ea11e9618855da55d09e6f953730686",
+            "OptimismPortalProxy": "0x91493a61ab83b62943e6dcaa5475dd330704cc84",
+            "SystemConfigProxy": "0x886b187c3d293b1449a3a0f23ca9e2269e0f2664",
+            "ProxyAdmin": "0xb570f4ad27e7de879a2e4f2f3de27dbabc20e9b9",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Guardian": "0xce10372313ca39fbf75a09e7f4c0e57f070259f4",
+            "Challenger": "0xce10372313ca39fbf75a09e7f4c0e57f070259f4",
+            "Proposer": "0x74bad482a7f73c8286f50d8aa03e53b7d24a5f3b",
+            "UnsafeBlockSigner": "0xceed24b1fd4a4393f6a9d2b137d9597dd5482569",
+            "BatchSubmitter": "0xf8db8aba597ff36ccd16fecfbb1b816b3236e9b8"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Shape",
+          "l2_chain_id": 360,
+          "PublicRPC": "https://mainnet.shape.network/",
+          "SequencerRPC": "https://shape-mainnet-sequencer.g.alchemy.com",
+          "Explorer": "https://shape-mainnet.explorer.alchemy.com/",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000360",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 1727370000,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 20369793,
+              "hash": "0x64772c7ca14e37ca9f0662b7d16b250f486218656012c0da994396608584b2b1"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xf17c665ffdebe214ec214bcd798c725141e7b5c29799500abd6a8738d15bdebe"
+            },
+            "l2_time": 1721744471,
+            "system_config": {
+              "batcherAddress": "0xf7ca543d652e38692fd12f989eb55b5327ec9a20",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xcee78437ae9e15cee9c78e63757e0153c0fd7479",
+            "L1CrossDomainMessengerProxy": "0x2b18602877181c3cb72c687e2a771e123a3788e3",
+            "L1Erc721BridgeProxy": "0xe9d3e49b0636016c5fe9eaa2347948d0ba9f15af",
+            "L1StandardBridgeProxy": "0x62edd5f4930ea92dca3fb81689bdd9b9d076b57b",
+            "L2OutputOracleProxy": "0x6ef8c69cfe4635d866e3e02732068022c06e724d",
+            "OptimismMintableErc20FactoryProxy": "0x319322906beadf69df5d4607169c63d692b1adc1",
+            "OptimismPortalProxy": "0xeb06ffa16011b5628bab98e29776361c83741dd3",
+            "SystemConfigProxy": "0xff11e41d5c4f522e423ff6c064ff8d55af8f7355",
+            "ProxyAdmin": "0x11b190ae661c6d6884dfee48e215691e0ddb842e",
+            "AnchorStateRegistryProxy": "0x02987e7294379b9dda99d593b0c94c68266222d1",
+            "DelayedWethProxy": "0xfec7865dac5139886585f03146ff61d9b31c2d57",
+            "DisputeGameFactoryProxy": "0x575aecd84083f93877291901907698f7db0bd8b0",
+            "FaultDisputeGame": null,
+            "Mips": "0xd30c2cd3cd6112e61fdfb03e4b232564d7e5c91f",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0xdf6a16a71d0bc7a1bbe8fffb33700ec3d9448a5b"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xee1af3f99af8c5b93512fbe2a3f0dd5568ce087f",
+            "ProxyAdminOwner": "0xacaf178b5048cb56712dc59e95fba72f7990a005",
+            "Guardian": "0xee1af3f99af8c5b93512fbe2a3f0dd5568ce087f",
+            "Challenger": "0xee1af3f99af8c5b93512fbe2a3f0dd5568ce087f",
+            "Proposer": "0x0d8a607f3d2de86add04df00f06794cb339a40de",
+            "UnsafeBlockSigner": "0x9c66333c504f3a4f5593d0e9739434744ccc5b5d",
+            "BatchSubmitter": "0xf7ca543d652e38692fd12f989eb55b5327ec9a20"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "World Chain",
+          "l2_chain_id": 480,
+          "PublicRPC": "https://worldchain-mainnet.g.alchemy.com/public",
+          "SequencerRPC": "https://worldchain-mainnet-sequencer.g.alchemy.com",
+          "Explorer": "https://worldchain-mainnet.explorer.alchemy.com/",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000480",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1721826000,
+            "granite_time": 1727780400,
+            "holocene_time": 1738238400,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0xa",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 20170118,
+              "hash": "0x793daed4743301e00143be5533cd1dce0a741519e9e9c96588a9ad7dbb4d8db4"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x70d316d2e0973b62332ba2e9768dd7854298d7ffe77f0409ffdb8d859f2d3fa3"
+            },
+            "l2_time": 1719335639,
+            "system_config": {
+              "batcherAddress": "0xdbbe3d8c2d2b22a2611c5a94a9a12c2fcd49eb29",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 100000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x5891090d5085679714cb0e62f74950a3c19146a8",
+            "L1CrossDomainMessengerProxy": "0xf931a81d18b1766d15695ffc7c1920a62b7e710a",
+            "L1Erc721BridgeProxy": "0x1df436afdb2fbb40f1fe8bed4fc89a0d0990a8e9",
+            "L1StandardBridgeProxy": "0x470458c91978d2d929704489ad730dc3e3001113",
+            "L2OutputOracleProxy": "0x19a6d1e9034596196295cf148509796978343c5d",
+            "OptimismMintableErc20FactoryProxy": "0x82cb528466cf22412d89bdbe9bcf04856790dd0e",
+            "OptimismPortalProxy": "0xd5ec14a83b7d95be1e2ac12523e2dee12cbeea6c",
+            "SystemConfigProxy": "0x6ab0777fd0e609ce58f939a7f70fe41f5aa6300a",
+            "ProxyAdmin": "0xd7405be7f3e63b094af6c7c23d5ee33fd82f872d",
+            "AnchorStateRegistryProxy": "0xd4d7a57dcc563756ded99e224e144a6bf0327099",
+            "DelayedWethProxy": "0xf9adf7c9502c5c60352c20a4d22683422dbd061f",
+            "DisputeGameFactoryProxy": "0x069c4c579671f8c120b1327a73217d01ea2ec5ea",
+            "FaultDisputeGame": null,
+            "Mips": "0x5fe03a12c1236f9c22cb6479778ddaa4bce6299c",
+            "PermissionedDisputeGame": "0x55e6125f946f3cb24fc3e07dd7242f96ce512bd9",
+            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xb2aa0c2c4fd6bfcbf699d4c787cd6cc0dc461a9d",
+            "ProxyAdminOwner": "0xa4fb12d15eb85dc9284a7df0adbc8b696edbbf1d",
+            "Guardian": "0xb2aa0c2c4fd6bfcbf699d4c787cd6cc0dc461a9d",
+            "Challenger": "0xa4fb12d15eb85dc9284a7df0adbc8b696edbbf1d",
+            "Proposer": "0x2307278fc8ab0005974a6ded2fa6d1187333a223",
+            "UnsafeBlockSigner": "0x2270d6ec8e760daa317dd978cfb98c8f144b1f3a",
+            "BatchSubmitter": "0xdbbe3d8c2d2b22a2611c5a94a9a12c2fcd49eb29"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Binary Mainnet",
+          "l2_chain_id": 624,
+          "PublicRPC": "https://rpc.zero.thebinaryholdings.com",
+          "SequencerRPC": "https://sequencer.bnry.mainnet.zeeve.net",
+          "Explorer": "https://explorer.thebinaryholdings.com",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 1726070401,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000624",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1725536344,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 20175246,
+              "hash": "0xdcc5838ee3dd0af995c87bec9614a09f08dd8979014876b42fd7e3ae044dd8c4"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xe222b4b07ee9c885d13ee341823c92aa449f9769ac68fb5f1e1d4e602a990a4a"
+            },
+            "l2_time": 1719397463,
+            "system_config": {
+              "batcherAddress": "0x7f9d9c1bce1062e1077845ea39a0303429600a06",
+              "overhead": "0x0",
+              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x8173904703995c6bba59a42b8bbf8405f978758a",
+            "L1CrossDomainMessengerProxy": "0x807d21e416434ae92c8e5bca4d506781afbba380",
+            "L1Erc721BridgeProxy": "0x1b396e4dc6ecb0be33cf01c5a34e1a3a7d03c378",
+            "L1StandardBridgeProxy": "0xd1b30378cbf968e5525e8835219a5726a1e71d10",
+            "L2OutputOracleProxy": "0x012f4baa6e0f5ac4dfdf47bddd9cf68a2b17821e",
+            "OptimismMintableErc20FactoryProxy": "0xa641e14b685b5e652865e14a4fbc07e51371d124",
+            "OptimismPortalProxy": "0x5ff88fcf8e9947f45f4caf8ffd5231b5ddf05e0a",
+            "SystemConfigProxy": "0x7ac7e5989eac278b7bbfef560871a2026bad472c",
+            "ProxyAdmin": "0x38593cce8fab9887ef9760f5f6ab3d6c595143cf",
+            "AnchorStateRegistryProxy": "0x275abd1eb1fbaab40dcef5f3a588e2df65801edc",
+            "DelayedWethProxy": "0x161914f701d090824c1a8a0f4e5666938f12848d",
+            "DisputeGameFactoryProxy": "0x0d7e0590c58e4ac9b14b3ed6163cf55223931699",
+            "FaultDisputeGame": null,
+            "Mips": "0x4e66d89ddf5a9d86836abb1d05ff8fdb5ad32c9a",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0xb9ff3a5835144b0d2f4267a21e0c74458907c870"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x25a6e7c6f3d0fe89a656fcf065614b74e55099ff",
+            "ProxyAdminOwner": "0x48ec051349ddc7e8babafcbfe27696ecf2a8a8b3",
+            "Guardian": "0x87aab081ac9f8ce80fb048f23280df019036ba1d",
+            "Challenger": "0x79ddf0745d14783cdc2a05624c585ddce07f4a02",
+            "Proposer": "0x2b6cd940abe0caf2fd89155b99522548c00ebab1",
+            "UnsafeBlockSigner": "0xdbad225d1c0dabc27f6a9d250dbb136413c0dfb4",
+            "BatchSubmitter": "0x7f9d9c1bce1062e1077845ea39a0303429600a06"
+          },
+          "GasPayingToken": "0x04e9d7e336f79cdab911b06133d3ca2cd0721ce3"
+        },
+        {
+          "Name": "Redstone",
+          "l2_chain_id": 690,
+          "PublicRPC": "https://rpc.redstonechain.com",
+          "SequencerRPC": "https://rpc.redstonechain.com",
+          "Explorer": "https://explorer.redstone.xyz",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000690",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": null,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": "0x2",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0x32"
+          },
+          "alt_da": {
+            "da_challenge_address": null,
+            "da_challenge_window": 3600,
+            "da_resolve_window": 3600
+          },
+          "genesis": {
+            "l1": {
+              "number": 19578374,
+              "hash": "0xb9ec694afdde2e2ed661ed8ec56dace5cf8723801342fa1229e693f2a98af672"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xa4f55631013577464810893a05b18f07fe483885a6ef93e0060e7128bdf4ca3b"
+            },
+            "l2_time": 1712185091,
+            "system_config": {
+              "batcherAddress": "0xa31cb9bc414601171d4537580f98f66c03aecd43",
+              "overhead": "0x1",
+              "scalar": "0x1def",
+              "gasLimit": 100000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xfe27f187a9e46104a932189ddf229871e06b22f8",
+            "L1CrossDomainMessengerProxy": "0x592c1299e0f8331d81a28c0fc7352da24edb444a",
+            "L1Erc721BridgeProxy": "0x4ffb98dbc3086ba85d5e626a6ebc3d0d08533ff4",
+            "L1StandardBridgeProxy": "0xc473ca7e02af24c129c2eef51f2adf0411c1df69",
+            "L2OutputOracleProxy": "0xa426a052f657aeeefc298b3b5c35a470e4739d69",
+            "OptimismMintableErc20FactoryProxy": "0x5f962474834cf1981df6232e4b6431d3d10cb71d",
+            "OptimismPortalProxy": "0xc7bcb0e8839a28a1cfadd1cf716de9016cda51ae",
+            "SystemConfigProxy": "0x8f2428f7189c0d92d1c4a5358903a8c80ec6a69d",
+            "ProxyAdmin": "0xcc53b447afe07926423ab96d5496b1af30485ed2",
+            "AnchorStateRegistryProxy": "0xc51ac31bcefb64d999af10129cb7693eee7c1179",
+            "DelayedWethProxy": "0xa130523fd22e2a9d78f8ab232b01ff552845b4a9",
+            "DisputeGameFactoryProxy": "0x8f68e849eaf8eb943536f9d1d49ea9c9b5868b98",
+            "FaultDisputeGame": null,
+            "Mips": "0x66d6be83984e3f026b4a9e2d8fb082ecdbd43648",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0xe7d0fe72637b3c949cd81c63a4ff1fb23feef3b2"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xb356b146f1629c49c44344464f69bcdafb4bb664",
+            "ProxyAdminOwner": "0x70fdbcb066ed3621647ddf61a1f40aac6058bc89",
+            "Guardian": "0xb356b146f1629c49c44344464f69bcdafb4bb664",
+            "Challenger": "0xb356b146f1629c49c44344464f69bcdafb4bb664",
+            "Proposer": "0x4c465e58946145bb2bfc38833154f5a3b5728cf7",
+            "UnsafeBlockSigner": "0xa5bdf717af725a47fd7378d3d9c833776951efa0",
+            "BatchSubmitter": "0xa31cb9bc414601171d4537580f98f66c03aecd43"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Lyra Chain",
+          "l2_chain_id": 957,
+          "PublicRPC": "https://rpc.lyra.finance",
+          "SequencerRPC": "https://rpc.lyra.finance",
+          "Explorer": "https://explorer.lyra.finance",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x5f7f7f6db967f0ef10bda0678964dba185d16c50",
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 18574841,
+              "hash": "0x00b06b23108483a0b6af8ff726b5ed3f508b7986f72c12679b10d72c05839716"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x047f535b3da7ad4f96d353b5a439740b7591413daee0e2f27dd3aabb24581af2"
+            },
+            "l2_time": 1700021615,
+            "system_config": {
+              "batcherAddress": "0x14e4e97bdc195d399ad8e7fc14451c279fe04c8e",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xc845f9c4004eb35a8bde8ad89c4760a9c0e65cab",
+            "L1CrossDomainMessengerProxy": "0x5456f02c08e9a018e42c39b351328e5aa864174a",
+            "L1Erc721BridgeProxy": "0x6cc3268794c5d3e3d9d52adefc748b59d536cb22",
+            "L1StandardBridgeProxy": "0x61e44dc0dae6888b5a301887732217d5725b0bff",
+            "L2OutputOracleProxy": "0x1145e7848c8b64c6cab86fd6d378733385c5c3ba",
+            "OptimismMintableErc20FactoryProxy": "0x08dea366f26c25a08c8d1c3568ad07d1e587136d",
+            "OptimismPortalProxy": "0x85ea9c11cf3d4786027f7fd08f4406b15777e5f8",
+            "SystemConfigProxy": "0x0e4c4cdd01cecb01070e9fdfe7600871e4ae996e",
+            "ProxyAdmin": "0x35d5d43271548c984662d4879fbc8e041bc1ff93",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Guardian": "0x91f4be0c264fafa1fed75c4440910cba2cad98e8",
+            "Challenger": "0x91f4be0c264fafa1fed75c4440910cba2cad98e8",
+            "Proposer": "0x03e820562ffd2e0390787cad706eaf1ff98c2608",
+            "UnsafeBlockSigner": "0xb71b58ffe538628557433dbbfa08d45ee5a69b44",
+            "BatchSubmitter": "0x14e4e97bdc195d399ad8e7fc14451c279fe04c8e"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Lisk",
+          "l2_chain_id": 1135,
+          "PublicRPC": "https://rpc.api.lisk.com",
+          "SequencerRPC": "https://rpc.api.lisk.com",
+          "Explorer": "https://blockscout.lisk.com",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xff00000000000000000000000000000000001135",
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x14",
+            "eip1559Denominator": "0x3e8",
+            "eip1559DenominatorCanyon": "0x3e8"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 19788720,
+              "hash": "0xd580bdbd001908860f225c16ddaa08ada64471a68435694760c111253d97ffce"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x5a693d1d8ee27b8e62868d0349af430a2d2e173c8c8988e7b0c9ef91893cbf00"
+            },
+            "l2_time": 1714728791,
+            "system_config": {
+              "batcherAddress": "0xa6ea2f3299b63c53143c993d2d5e60a69cd6fe24",
+              "overhead": "0xbc",
+              "scalar": "0xf4240",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x2df7057d3f25212e51afea8da628668229ea423f",
+            "L1CrossDomainMessengerProxy": "0x31b72d76fb666844c41edf08df0254875dbb7edb",
+            "L1Erc721BridgeProxy": "0x3a44a3b263fb631cdbf25f339e2d29497511a81f",
+            "L1StandardBridgeProxy": "0x2658723bf70c7667de6b25f99fcce13a16d25d08",
+            "L2OutputOracleProxy": "0x113cb99283af242da0a0c54347667edf531aa7d6",
+            "OptimismMintableErc20FactoryProxy": "0xc1da06cc5dd5ce23baba924463de7f762039252d",
+            "OptimismPortalProxy": "0x26db93f8b8b4f7016240af62f7730979d353f9a7",
+            "SystemConfigProxy": "0x05f23282ffdca8286e4738c1af79079f3d843750",
+            "ProxyAdmin": "0xec432c4f1d0e12737f3a42a459b84848af979b2d",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": "0x0479e6757eb4743843b309dddf78e6ba242f38be",
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
+            "ProxyAdminOwner": "0xecd4150abbb1ebff13f74e42fb43c3d78b4e0b45",
+            "Guardian": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
+            "Challenger": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
+            "Proposer": "0x0abd6da1ce10d1cd6c7c9c14b905786d20f3eb23",
+            "UnsafeBlockSigner": "0xb9de90a90c5e441c483e754fe7341100d5fbaeca",
+            "BatchSubmitter": "0xa6ea2f3299b63c53143c993d2d5e60a69cd6fe24"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Metal L2",
+          "l2_chain_id": 1750,
+          "PublicRPC": "https://rpc.metall2.com",
+          "SequencerRPC": "https://rpc.metall2.com",
+          "Explorer": "https://explorer.metall2.com",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xc83f7d9f2d4a76e81145849381aba02602373723",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 19527340,
+              "hash": "0x2493565ce8472656b7c22377c8d4d8ef5d17f78392c799ca5f2429b01e2c159c"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xd31c12ffff2d563897ad9a041c0d26790d635911bdbbfa589347fa955f75281e"
+            },
+            "l2_time": 1711563515,
+            "system_config": {
+              "batcherAddress": "0xc94c243f8fb37223f3eb2f7961f7072602a51b8b",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xd4b1ec0dec3c7f12abd3ec27b7514880ae1c3a37",
+            "L1CrossDomainMessengerProxy": "0x0a47a44f1b2bb753474f8c830322554a96c9934d",
+            "L1Erc721BridgeProxy": "0x50d700e97967f9115e3f999bdb263d69f6704680",
+            "L1StandardBridgeProxy": "0x6d0f65d59b55b0fec5d2d15365154dcadc140bf3",
+            "L2OutputOracleProxy": "0x3b1f7ada0fcc26b13515af752dd07fb1cac11426",
+            "OptimismMintableErc20FactoryProxy": "0x1aaab4e20d2e4bb992b5bca2125e8bd3588c8730",
+            "OptimismPortalProxy": "0x3f37abde2c6b5b2ed6f8045787df1ed1e3753956",
+            "SystemConfigProxy": "0x7bd909970b0eedcf078de6aeff23ce571663b8aa",
+            "ProxyAdmin": "0x37ff0ae34dada1a95a4251d10ef7caa868c7ac99",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
+            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
+            "Challenger": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Proposer": "0xc8187d40ad440328104a52bbed2d8efc5ab1f1f6",
+            "UnsafeBlockSigner": "0x4a65f5da5e80deffea844eaa15ce130e80605dc5",
+            "BatchSubmitter": "0xc94c243f8fb37223f3eb2f7961f7072602a51b8b"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Soneium",
+          "l2_chain_id": 1868,
+          "PublicRPC": "https://rpc.soneium.org",
+          "SequencerRPC": "https://rpc.soneium.org",
+          "Explorer": "https://soneium.blockscout.com/",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 1738573200,
+          "batch_inbox_address": "0x008dc74cecc9deda8595b2fe210ce5979f0bfa8e",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 0,
+            "holocene_time": 1738573200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 21314185,
+              "hash": "0x68b4ad05c3dafc2613853d26cf39f0e1716e986f879207440f187b56c12cb4d6"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x295d22d269634c7d0055b33b887519362d0b31899e97109d1789a8a168de1b21"
+            },
+            "l2_time": 1733134751,
+            "system_config": {
+              "batcherAddress": "0x6776be80dbada6a02b5f2095cf13734ac303b8d1",
+              "overhead": "0x0",
+              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
+              "gasLimit": 60000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xb24bfeece1b3b7a44559f4cbc21bed312b130b70",
+            "L1CrossDomainMessengerProxy": "0x9cf951e3f74b644e621b36ca9cea147a78d4c39f",
+            "L1Erc721BridgeProxy": "0x5933e323be8896dfacd1cd671442f27daa10a053",
+            "L1StandardBridgeProxy": "0xeb9bf100225c214efc3e7c651ebbadcf85177607",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": "0xc1047e30efc9e172cfe7aa0219895b6a43fc415f",
+            "OptimismPortalProxy": "0x88e529a6ccd302c948689cd5156c83d4614fae92",
+            "SystemConfigProxy": "0x7a8ed66b319911a0f3e7288bddab30d9c0c875c3",
+            "ProxyAdmin": "0x89889b569c3a505f3640ee1bd0ac1d557f436d2a",
+            "AnchorStateRegistryProxy": "0x61f89a381e0be13bd8ab356cf4b7301bc97d7522",
+            "DelayedWethProxy": "0x9cf951e3f74b644e621b36ca9cea147a78d4c39f",
+            "DisputeGameFactoryProxy": "0x512a3d2c7a43bd9261d2b8e8c9c70d4bd4d503c0",
+            "FaultDisputeGame": null,
+            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
+            "PermissionedDisputeGame": "0x42d15f045159ce4ade9edc7da5704ef36056c936",
+            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x509182ec226b3b71d36a3255a80ef0b1a9d43033",
+            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
+            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
+            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
+            "Proposer": "0x400c164c4a8ca84385b70eed6eb03ea847c8e1b8",
+            "UnsafeBlockSigner": "0x7c2bd59ee2a2c7391c9a240132f26071e9546262",
+            "BatchSubmitter": "0x6776be80dbada6a02b5f2095cf13734ac303b8d1"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Swellchain",
+          "l2_chain_id": 1923,
+          "PublicRPC": "https://swell-mainnet.alt.technology",
+          "SequencerRPC": "https://swell-mainnet.alt.technology",
+          "Explorer": "https://explorer.swellnetwork.io",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0x005de5857e38dfd703a1725c0900e9c6f24cbde0",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 0,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 21277945,
+              "hash": "0xd904f8475cc7b74a9ef4749d0ee9aeca3b233aa3dc143667e8a20ffe43789a26"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x92379973a1576876b7337a9ce89e2a7a9cb99887f55e6045ed2069d5d98d9319"
+            },
+            "l2_time": 1732696703,
+            "system_config": {
+              "batcherAddress": "0xf854cd5b26bfd73d51236c0122798907ed65b1f2",
+              "overhead": "0x0",
+              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
+              "gasLimit": 60000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xa54a84f17c2180148c762d79bc57bdff7fdafc8a",
+            "L1CrossDomainMessengerProxy": "0xe6a99ef12995defc5ff47ec0e13252f0e6903759",
+            "L1Erc721BridgeProxy": "0xfd7618330e63b493070dc8c491ad4ad26144bc1e",
+            "L1StandardBridgeProxy": "0x7aa4960908b13d104bf056b23e2c76b43c5aacc8",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": "0xc2b228cd433ebae788de287ede2abe55b3f3f603",
+            "OptimismPortalProxy": "0x758e0ee66102816f5c3ec9ecc1188860fbb87812",
+            "SystemConfigProxy": "0xd3d4c6b703978a5d24fecf3a70a51127667ff1a4",
+            "ProxyAdmin": "0x4c4710a4ec3f514a492cc6460818c4a6a6269dd6",
+            "AnchorStateRegistryProxy": "0x14387438ee964e826a4eaeb95b2bce7754174dd1",
+            "DelayedWethProxy": "0x89c98736a806176fe85283c1cb727ffbdeaf37a9",
+            "DisputeGameFactoryProxy": "0x87690676786cdc8cca75a472e483af7c8f2f0f57",
+            "FaultDisputeGame": null,
+            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
+            "PermissionedDisputeGame": "0xa0cfbe3402d6e0a74e96d3c360f74d5ea4fa6893",
+            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x06f7fb1c74147e34fce04a6828c7bf809b038d0e",
+            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
+            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
+            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
+            "Proposer": "0xfe5dd32c3799249dc6a5d637ccb2f28e0ec227e3",
+            "UnsafeBlockSigner": "0x6967d304e9b7e26b5eb3f5a1fd1239daad3215e6",
+            "BatchSubmitter": "0xf854cd5b26bfd73d51236c0122798907ed65b1f2"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Superseed",
+          "l2_chain_id": 5330,
+          "PublicRPC": "https://mainnet.superseed.xyz",
+          "SequencerRPC": "https://mainnet.superseed.xyz",
+          "Explorer": "https://explorer.superseed.xyz",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0x8612014a343089f1ddbacfd42baf4afbf9133593",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 20737477,
+              "hash": "0x32566bf75b83734e532a687ad0c1d0b884e544815498401696ca5a49df238cf2"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x0e5eb156fd2ea921d57ee4921191a2a46ebe3a11854ee7a63a5c6c580aa99219"
+            },
+            "l2_time": 1726179683,
+            "system_config": {
+              "batcherAddress": "0xa9b074b27de97f492f8f07fd7c213400e4ca5391",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x0a1b34aa2047ad1abef8ac085b1a7802ed9dbcf0",
+            "L1CrossDomainMessengerProxy": "0x3a30aed8fa7717ac2d8454d82c125cf6b875061a",
+            "L1Erc721BridgeProxy": "0xa99f82730e68968a78aa21522fc7eb90db76d8cb",
+            "L1StandardBridgeProxy": "0x8b0576e39f1233679109f9b40cfcc2a7e0901ede",
+            "L2OutputOracleProxy": "0x693a0f8854f458d282de3c5b69e8ee5eee8aa949",
+            "OptimismMintableErc20FactoryProxy": "0x484529223d68a0cf85902bf5e781394f0d0f837c",
+            "OptimismPortalProxy": "0x2c2150aa5c75a24fb93d4fd2f2a895d618054f07",
+            "SystemConfigProxy": "0x525a2744134805516a45b8abb6aa0aa1da3809f6",
+            "ProxyAdmin": "0xf3b7697c9c0cbde923f34991f2d19cc1c66612bd",
+            "AnchorStateRegistryProxy": "0xac1e4b08300c6c4705918089ee10b286b3ec24df",
+            "DelayedWethProxy": "0xec4dc88475a2887e73b2073b60425575fd693c0a",
+            "DisputeGameFactoryProxy": "0x8b097cf1f9bbd9cbfd0dd561858a1fcbc8857be0",
+            "FaultDisputeGame": null,
+            "Mips": "0x7f4f96cd3719f2829117c8c5e810e01dbd6846ba",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0xb18202e3e4dbf7abcea623a38526aad5a64dcd59"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Guardian": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
+            "Challenger": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Proposer": "0xb2354bdf5925d03ca06b03a7bd7386bd685ce814",
+            "UnsafeBlockSigner": "0x92dc533201e8634f0337d66a11820a8c4e902474",
+            "BatchSubmitter": "0xa9b074b27de97f492f8f07fd7c213400e4ca5391"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "RACE Mainnet",
+          "l2_chain_id": 6805,
+          "PublicRPC": "https://racemainnet.io",
+          "SequencerRPC": "https://racemainnet.io",
+          "Explorer": "https://racescan.io/",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000006805",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": null,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 20260129,
+              "hash": "0xb6fd41e6c3515172c36d3912046264475eaad84c2c56e99d74f4abd1a75b63c9"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xa864791943836c37b40ea688f3853f2198afb683a3e168d48bfa76c9896e3e65"
+            },
+            "l2_time": 1720421591,
+            "system_config": {
+              "batcherAddress": "0x8cda8351236199af7532bad53d683ddd9b275d89",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x3d2bde87466cae97011702d2c305fd40eebbbf0a",
+            "L1CrossDomainMessengerProxy": "0xf54b2baef894cff5511a5722acaac0409f2f2d89",
+            "L1Erc721BridgeProxy": "0x0f33d824d74180598311b3025095727bea61f219",
+            "L1StandardBridgeProxy": "0x680969a6c58183987c8126ca4de6b59c6540cd2a",
+            "L2OutputOracleProxy": "0x8bf8442d49d52377d735a90f19657a29f29aa83c",
+            "OptimismMintableErc20FactoryProxy": "0x1d1c4c89ad5ff486c3c67e3dd84a22cf05420711",
+            "OptimismPortalProxy": "0x0485ca8a73682b3d3f5ae98cdca1e5b512e728e9",
+            "SystemConfigProxy": "0xcf6a32db8b3313b3d439ce6909511c2c3415fa32",
+            "ProxyAdmin": "0x9b3c6d1d33f1fd82ebb8dfbe38da162b329de191",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xbac1ad52745162c0aa3711fe88df1cc67034a3b9",
+            "ProxyAdminOwner": "0x5a669b2193718f189b0576c0cdcedfed6f40f9ea",
+            "Guardian": "0x2e7b9465b25c081c07274a31dbd05c6146f67961",
+            "Challenger": "0x2e7b9465b25c081c07274a31dbd05c6146f67961",
+            "Proposer": "0x88d58bfbcd70c25409b67117fc1cdfefda113a78",
+            "UnsafeBlockSigner": "0x9b5639d472d6764b70f5046ac0b13438718398e0",
+            "BatchSubmitter": "0x8cda8351236199af7532bad53d683ddd9b275d89"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Cyber Mainnet",
+          "l2_chain_id": 7560,
+          "PublicRPC": "https://rpc.cyber.co",
+          "SequencerRPC": "https://cyber.alt.technology/",
+          "Explorer": "https://cyberscan.co/",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000001d88",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": null,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": {
+            "da_challenge_address": null,
+            "da_challenge_window": 3600,
+            "da_resolve_window": 3600
+          },
+          "genesis": {
+            "l1": {
+              "number": 19681125,
+              "hash": "0x8fa2a34b37420b863aa33da7661a8929af8bd7a436b9e612c727eb5e63da3879"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x0bbf36c47db3b42b40b2e6cadc183612337d1ac8602eb9e57071ae0043e70fc7"
+            },
+            "l2_time": 1713428567,
+            "system_config": {
+              "batcherAddress": "0xf0748c52edc23135d9845cdfb91279cf61ee14b4",
+              "overhead": "0xb4",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x19b5804b88f10262a55ac731f28a3bbc4209853a",
+            "L1CrossDomainMessengerProxy": "0x3c01ebf22e9c111528c1e027d68944edab08dfc9",
+            "L1Erc721BridgeProxy": "0x4f4b716627d2ba0439327ce8b563b4443af47dbd",
+            "L1StandardBridgeProxy": "0x12a580c05466eefb2c467c6b115844cdaf55b255",
+            "L2OutputOracleProxy": "0xa669a743b065828682ee16109273f5cfef5e676d",
+            "OptimismMintableErc20FactoryProxy": "0x51a00470eb50d758ecff3b96db0bf4a8e86268f4",
+            "OptimismPortalProxy": "0x1d59bc9fce6b8e2b1bf86d4777289ffd83d24c99",
+            "SystemConfigProxy": "0x5d1f4bbaf6d484fa9d5d9705f92de6063bff6055",
+            "ProxyAdmin": "0x7e54107731ec43e78da678dfa5fb6222ad036e03",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": "0x588dad44201885ff23068f1142e303d52d103919",
+            "DisputeGameFactoryProxy": "0xbf4676f21a7889e0fd61bcdc9b98e60b01c1b36f",
+            "FaultDisputeGame": null,
+            "Mips": "0x0048defca9f0da952cfd1ae9f8e962937d3e4143",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x0747ef2570e3dbf65f0a12b371f19ca4a66a8dde"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xc76c563185d01284adbc9cf5bb909162dd2f15e7",
+            "ProxyAdminOwner": "0xc2259e7fb719411f97abdcdf449f6ba3b9d75398",
+            "Guardian": "0x0c883f622b4ccbf1e8ce86217998f87e6d36bce4",
+            "Challenger": "0x87bd2cff3b59d615b1eac7a7f809b5e5f0ee6752",
+            "Proposer": "0xf2987f0a626c8d29dfb2e0a21144ca3026d6f1e1",
+            "UnsafeBlockSigner": "0xa7a4d6d5920b93d0fe590f9524ef17f24ee1f5b8",
+            "BatchSubmitter": "0xf0748c52edc23135d9845cdfb91279cf61ee14b4"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "arena-z",
+          "l2_chain_id": 7897,
+          "PublicRPC": "https://rpc.arena-z.gg",
+          "SequencerRPC": "https://rpc.arena-z.gg",
+          "Explorer": "https://explorer.arena-z.gg",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 1736445601,
+          "batch_inbox_address": "0x00f9bcee08dce4f0e7906c1f6cfb10c77802eed0",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 0,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x14",
+            "eip1559Denominator": "0x7d0",
+            "eip1559DenominatorCanyon": "0x7d0"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 21167590,
+              "hash": "0x5e7db5c04973dd6e06ac7e2abf5b9373089f0f09e8ae8231642f0c6aff177e27"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xbe7112a730b1fae8d94115271adc600559ebe87c75df1d2df9414bd7298eb7fb"
+            },
+            "l2_time": 1731366083,
+            "system_config": {
+              "batcherAddress": "0x2b8733e8c60a928b19bb7db1d79b918e8e09ac8c",
+              "overhead": "0x0",
+              "scalar": "0x10000000000000000000000000000000000000000000000000c3a30000060a4",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x1cb5fb7da1444e2d895420442d246787b7afa95d",
+            "L1CrossDomainMessengerProxy": "0x0be364912219bc74760f1d1c25f4866b328ebfc6",
+            "L1Erc721BridgeProxy": "0xbc404ae11e4e9da3ea9276aa6dcca31097d4f4ee",
+            "L1StandardBridgeProxy": "0x564eb0cefcca86160649a8986c419693c82f3678",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": "0xa33f75a3a2babd502cbc1a6f54345b529c1f306e",
+            "OptimismPortalProxy": "0xb20f99b598e8d888d1887715439851bc68806b22",
+            "SystemConfigProxy": "0x34a564bbd863c4bf73eca711cf38a77c4ccbdd6a",
+            "ProxyAdmin": "0xeefd1782d70824cbcacf9438afab7f353f1797f0",
+            "AnchorStateRegistryProxy": "0x924911e2ccadb4638447ccd00b6cfb040cc08560",
+            "DelayedWethProxy": "0xaf1308930b721e763a6b21cf143e4e86e702f164",
+            "DisputeGameFactoryProxy": "0x658656a14afdf9c507096ac406564497d13ec754",
+            "FaultDisputeGame": null,
+            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
+            "PermissionedDisputeGame": "0x227882e5972ebad990dcf04e2dbe2fc84094e146",
+            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
+            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
+            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
+            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
+            "Proposer": "0x5f16e66d8736b689a430564a31c8d887ca357cd8",
+            "UnsafeBlockSigner": "0xb774ca8438319d2a97b9925f4cd248e4c470ac5b",
+            "BatchSubmitter": "0x2b8733e8c60a928b19bb7db1d79b918e8e09ac8c"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Polynomial",
+          "l2_chain_id": 8008,
+          "PublicRPC": "https://rpc.polynomial.fi",
+          "SequencerRPC": "https://rpc.polynomial.fi",
+          "Explorer": "https://polynomialscan.io",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x0bd57e83b5e0f9ecd84d559bb58e1ecfeedd2565",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 20062729,
+              "hash": "0xc6d18992ff6e4c9e4798d34a7b97423a7ec276e9f2bbecfd4bb69ccdd49f516a"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x1b5e76ad2f290fb6fa2c60755d8c52942dbefedab76d01091e24080d5c129fd0"
+            },
+            "l2_time": 1718038175,
+            "system_config": {
+              "batcherAddress": "0x67a44ce38627f46f20b1293960559ed85dd194f1",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x287bba8116f2fc5a642bfd6027ebf5ad6522655c",
+            "L1CrossDomainMessengerProxy": "0x36725a5e0040deb7c697d46c0e24390702b202e0",
+            "L1Erc721BridgeProxy": "0xd5890bbafafdce942597757385e55174569e8d1a",
+            "L1StandardBridgeProxy": "0x3be64bf2b9c2de637067c7aab6bae5edf9feba55",
+            "L2OutputOracleProxy": "0xe512d477cc89196af2ce837f6ab8ea30e199f757",
+            "OptimismMintableErc20FactoryProxy": "0x994233366c8e11da5c525ab903c04e7afb2915bd",
+            "OptimismPortalProxy": "0x034cbb620d1e0e4c2e29845229beac57083b04ec",
+            "SystemConfigProxy": "0x58b51fb9feed00dd846f91d265eba3cdd855a413",
+            "ProxyAdmin": "0x3c68b1d45f4faa4f028c3dc8910fa3247c7f0a1f",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Guardian": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Challenger": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "Proposer": "0x5da28f0186051a9f7b9ee2553ffdc165eb0a6714",
+            "UnsafeBlockSigner": "0x11e2785dcc88fbd03ea71df324cbbb0a529b88a2",
+            "BatchSubmitter": "0x67a44ce38627f46f20b1293960559ed85dd194f1"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Base",
+          "l2_chain_id": 8453,
+          "PublicRPC": "https://mainnet.base.org",
+          "SequencerRPC": "https://mainnet-sequencer.base.org",
+          "Explorer": "https://explorer.base.org",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xff00000000000000000000000000000000008453",
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 17481768,
+              "hash": "0x5c13d307623a926cd31415036c8b7fa14572f9dac64528e857a470511fc30771"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
+            },
+            "l2_time": 1686789347,
+            "system_config": {
+              "batcherAddress": "0x5050f69a9786f081509234f1a7f4684b5e5b76c9",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x8efb6b5c4767b09dc9aa6af4eaa89f749522bae2",
+            "L1CrossDomainMessengerProxy": "0x866e82a600a1414e583f7f13623f1ac5d58b0afa",
+            "L1Erc721BridgeProxy": "0x608d94945a64503e642e6370ec598e519a2c1e53",
+            "L1StandardBridgeProxy": "0x3154cf16ccdb4c6d922629664174b904d80f2c35",
+            "L2OutputOracleProxy": "0x56315b90c40730925ec5485cf004d835058518a0",
+            "OptimismMintableErc20FactoryProxy": "0x05cc379ebd9b30bba19c6fa282ab29218ec61d84",
+            "OptimismPortalProxy": "0x49048044d57e1c92a77f79988d21fa8faf74e97e",
+            "SystemConfigProxy": "0x73a79fab69143498ed3712e519a88a918e1f4072",
+            "ProxyAdmin": "0x0475cbcaebd9ce8afa5025828d5b98dfb67e059e",
+            "AnchorStateRegistryProxy": "0xdb9091e48b1c42992a1213e6916184f9ebdbfedf",
+            "DelayedWethProxy": "0xa2f2ac6f5af72e494a227d79db20473cf7a1ffe8",
+            "DisputeGameFactoryProxy": "0x43edb88c4b80fdd2adff2412a7bebf9df42cb40e",
+            "FaultDisputeGame": "0xcd3c0194db74c23807d4b90a5181e1b28cf7007c",
+            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
+            "PermissionedDisputeGame": "0x19009debf8954b610f207d5925eede827805986e",
+            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x14536667cd30e52c0b458baaccb9fada7046e056",
+            "ProxyAdminOwner": "0x7bb41c3008b3f03fe483b28b8db90e19cf07595c",
+            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
+            "Challenger": "0x6f8c5ba3f59ea3e76300e3becdc231d656017824",
+            "Proposer": "0x642229f238fb9de03374be34b0ed8d9de80752c5",
+            "UnsafeBlockSigner": "0xaf6e19be0f9ce7f8afd49a1824851023a8249e8a",
+            "BatchSubmitter": "0x5050f69a9786f081509234f1a7f4684b5e5b76c9"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Funki",
+          "l2_chain_id": 33979,
+          "PublicRPC": "https://rpc-mainnet.funkichain.com",
+          "SequencerRPC": "https://rpc-mainnet.funkichain.com",
+          "Explorer": "https://funki.superscan.network",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000084bb84bb",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 8400,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": "0xa",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": {
+            "da_challenge_address": null,
+            "da_challenge_window": 3600,
+            "da_resolve_window": 3600
+          },
+          "genesis": {
+            "l1": {
+              "number": 20325568,
+              "hash": "0xa0768467271297b618c4306469577fd14ba5b0c0488d6e9710a24762cbfe2928"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x7d2831dd811c616d073342a3074f2ce737c6b200b8192f9528e8bf32b1fac83e"
+            },
+            "l2_time": 1721211095,
+            "system_config": {
+              "batcherAddress": "0x73c98cf34af1f7d798e8e6f34b16037530bffc41",
+              "overhead": "0x0",
+              "scalar": "0x100000000000000000000000000000000000000000000000000000000003138",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x5a4ebf927338ea6af377caeee99c85088908f57d",
+            "L1CrossDomainMessengerProxy": "0x8f56a665c376a08b604dd32ee6e88667a6093172",
+            "L1Erc721BridgeProxy": "0x94519dd4ba8ba20aaad14f7c6cd00fa1bb0192e9",
+            "L1StandardBridgeProxy": "0xa2c1c1a473250094a6244f2bcf6cb51f670ad3ac",
+            "L2OutputOracleProxy": "0x1a9ae6486caec0504657351ac473b3df8a1367cb",
+            "OptimismMintableErc20FactoryProxy": "0x87e75dcc1bb4e5b42cb5c52eb5832d6ecc3bfef4",
+            "OptimismPortalProxy": "0x5c9c7f98ed153a2deaa981eb5c97b31744accf22",
+            "SystemConfigProxy": "0xd39a6cccfa23cb741bb530497e42ec337f1215a8",
+            "ProxyAdmin": "0xd069c4724f9bc15fa53b3b2516594512aef8c957",
+            "AnchorStateRegistryProxy": "0x48eb5a81cc3a8955d0dabd6eed45ac09c7c1889f",
+            "DelayedWethProxy": "0x7992352f723d1209cdd9b786def1fbd8dc6511db",
+            "DisputeGameFactoryProxy": "0x2dc9d2cb1ba0b8a46ae252ab4fbe1ad5c5c3b795",
+            "FaultDisputeGame": null,
+            "Mips": "0x29564d1b96a1308e6930f88665576763ed4837e2",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0xd8f66efec53cea76c597827ba5bf3f68d29f2fa8"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xc0ce2761d5cc92d25db6ccd95e4b9483ed22d11b",
+            "ProxyAdminOwner": "0x89cb6669f87c165e7128f4a57476ee4daa7ffbcd",
+            "Guardian": "0x052a8cd5967bc3bdb5660c989a3a68bca683a077",
+            "Challenger": "0x9f8b2470ffecbca2ffda20b9e10f6a12f33bc2ce",
+            "Proposer": "0x7a7690bbab496537ac59b45b4c59d789233bca16",
+            "UnsafeBlockSigner": "0x843458b6de651e02dfd5bffea0e9cfb3eca293ef",
+            "BatchSubmitter": "0x73c98cf34af1f7d798e8e6f34b16037530bffc41"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Mode",
+          "l2_chain_id": 34443,
+          "PublicRPC": "https://mainnet.mode.network",
+          "SequencerRPC": "https://mainnet-sequencer.mode.network",
+          "Explorer": "https://explorer.mode.network",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x24e59d9d3bd73ccc28dc54062af7ef7bff58bd67",
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 18586927,
+              "hash": "0xf9b1b22a7ef9d13f063ea467bcb70fb6e9f29698ecb7366a2cdf5af2165cacee"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xb0f682e12fc555fd5ce8fce51a59a67d66a5b46be28611a168260a549dac8a9b"
+            },
+            "l2_time": 1700167583,
+            "system_config": {
+              "batcherAddress": "0x99199a22125034c808ff20f377d91187e8050f2e",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x50ef494573f28cad6b64c31b7a00cdaa48306e15",
+            "L1CrossDomainMessengerProxy": "0x95bdca6c8edeb69c98bd5bd17660bacef1298a6f",
+            "L1Erc721BridgeProxy": "0x2901da832a4d0297ff0691100a8e496626cc626d",
+            "L1StandardBridgeProxy": "0x735adbbe72226bd52e818e7181953f42e3b0ff21",
+            "L2OutputOracleProxy": "0x4317ba146d4933d889518a3e5e11fe7a53199b04",
+            "OptimismMintableErc20FactoryProxy": "0x69216395a62dfb243c05ef4f1c27af8655096a95",
+            "OptimismPortalProxy": "0x8b34b14c7c7123459cf3076b8cb929be097d0c07",
+            "SystemConfigProxy": "0x5e6432f18bc5d497b1ab2288a025fbf9d69e2221",
+            "ProxyAdmin": "0x470d87b1dae09a454a43d1fd772a561a03276ab7",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
+            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
+            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
+            "Challenger": "0x309fe2536d01867018d120b40e4676723c53a14c",
+            "Proposer": "0x674f64d64ddc198db83cd9047df54bf89ccd0ddb",
+            "UnsafeBlockSigner": "0xa7fa9ca4ac88686a542c0f830d7378eab4a0278f",
+            "BatchSubmitter": "0x99199a22125034c808ff20f377d91187e8050f2e"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Ink",
+          "l2_chain_id": 57073,
+          "PublicRPC": "https://rpc-gel.inkonchain.com",
+          "SequencerRPC": "https://rpc-gel.inkonchain.com",
+          "Explorer": "https://explorer.inkonchain.com",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 1740582000,
+          "batch_inbox_address": "0x005969bf0ecbf6edb6c47e5e94693b1c3651be97",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 0,
+            "holocene_time": 1740582000,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 1,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0xfa",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 21344310,
+              "hash": "0x39e4e0c0c94f8076134b441a9dc18d10b595fd9777edeb763bb9f9bd8f922fd9"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x23a2658170ba70d014ba0d0d2709f8fbfe2fa660cd868c5f282f991eecbe38ee"
+            },
+            "l2_time": 1733498411,
+            "system_config": {
+              "batcherAddress": "0x500d7ea63cf2e501dadaa5feec1fc19fe2aa72ac",
+              "overhead": "0x0",
+              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x9b7c9bbd6d540a8a4dedd935819fc4408ba71153",
+            "L1CrossDomainMessengerProxy": "0x69d3cf86b2bf1a9e99875b7e2d9b6a84426c171f",
+            "L1Erc721BridgeProxy": "0x661235a238b11191211fa95d4dd9e423d521e0be",
+            "L1StandardBridgeProxy": "0x88ff1e5b602916615391f55854588efcbb7663f0",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": "0xa8b389a82e088b164cd03230e900980cced34d29",
+            "OptimismPortalProxy": "0x5d66c1782664115999c47c9fa5cd031f495d3e4f",
+            "SystemConfigProxy": "0x62c0a111929fa32cec2f76adba54c16afb6e8364",
+            "ProxyAdmin": "0xd56045e68956fce2576e680c95a4750cf8241f79",
+            "AnchorStateRegistryProxy": "0xde744491bcf6b2dd2f32146364ea1487d75e2509",
+            "DelayedWethProxy": "0x3beaca17eae5643fb1479aa5f4b1ff75cc4b9b50",
+            "DisputeGameFactoryProxy": "0x10d7b35078d3baabb96dd45a9143b94be65b12cd",
+            "FaultDisputeGame": "0x6a8efcba5642eb15d743cbb29545bdc44d5ad8cd",
+            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
+            "PermissionedDisputeGame": "0x0a780be3eb21117b1bbcd74cf5d7624a3a482963",
+            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
+            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
+            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
+            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
+            "Proposer": "0x65436ddcbc026f34118954f229f7f132b696b3b4",
+            "UnsafeBlockSigner": "0x7d056b99aa2021864c42e25b4f8ce3bdeac9463c",
+            "BatchSubmitter": "0x500d7ea63cf2e501dadaa5feec1fc19fe2aa72ac"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "BOB",
+          "l2_chain_id": 60808,
+          "PublicRPC": "https://rpc.gobob.xyz",
+          "SequencerRPC": "https://rpc.gobob.xyz",
+          "Explorer": "https://explorer.gobob.xyz",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x3a75346f81302aac0333fb5dcdd407e12a6cfa83",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 19634321,
+              "hash": "0x218132178d65c4bc490aadd93c31535326043fe1fe8fea2d87f26c1da83d45c2"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x8ed4903b7f9c3f7bb7a09374d63ae9c9852cd9aab1784b433c41dbeb47b4dba2"
+            },
+            "l2_time": 1712861987,
+            "system_config": {
+              "batcherAddress": "0x08f9f14ff43e112b18c96f0986f28cb1878f1d11",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xf2dc77c697e892542cc53336178a78bb313dfdc7",
+            "L1CrossDomainMessengerProxy": "0xe3d981643b806fb8030cdb677d6e60892e547eda",
+            "L1Erc721BridgeProxy": "0x5ff93263d5181b2a826f8c51d54bc0da2d20d50a",
+            "L1StandardBridgeProxy": "0x3f6ce1b36e5120bbc59d0cfe8a5ac8b6464ac1f7",
+            "L2OutputOracleProxy": "0xdda53e23f8a32640b04d7256e651c1db98db11c1",
+            "OptimismMintableErc20FactoryProxy": "0x5557408ab14013ce9dbb300de0d87d386bb09cb6",
+            "OptimismPortalProxy": "0x8adee124447435fe03e3cd24df3f4cae32e65a3e",
+            "SystemConfigProxy": "0xacb886b75d76d1c8d9248cfddfa09b70c71c5393",
+            "ProxyAdmin": "0x0d9f416260598313be6fdf6b010f2fbc34957cd0",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xc91482a96e9c2a104d9298d1980eccf8c4dc764e",
+            "ProxyAdminOwner": "0xc91482a96e9c2a104d9298d1980eccf8c4dc764e",
+            "Guardian": "0xc91482a96e9c2a104d9298d1980eccf8c4dc764e",
+            "Challenger": "0xc91482a96e9c2a104d9298d1980eccf8c4dc764e",
+            "Proposer": "0x7cb1022d30b9860c36b243e7b181a1d46f618c69",
+            "UnsafeBlockSigner": "0xb18ad28cb78fd2eafac6941c24c5135515b796f0",
+            "BatchSubmitter": "0x08f9f14ff43e112b18c96f0986f28cb1878f1d11"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Automata Mainnet",
+          "l2_chain_id": 65536,
+          "PublicRPC": "https://rpc.ata.network",
+          "SequencerRPC": "https://automata-mainnet.alt.technology/",
+          "Explorer": "https://explorer.ata.network",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000001111111",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 7200,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": "0xa",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": {
+            "da_challenge_address": null,
+            "da_challenge_window": 3600,
+            "da_resolve_window": 3600
+          },
+          "genesis": {
+            "l1": {
+              "number": 20323239,
+              "hash": "0x2f2ea5358078fdc01d978ff85a3a8fb2efff470b624ba95c5eef0ecd75a6e81d"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x11bb44203634fd85571a9971e6f09d633cbf22826681f809283081ff4e1b5192"
+            },
+            "l2_time": 1721183063,
+            "system_config": {
+              "batcherAddress": "0x5bef09f138921ef7985d83aab97da1db6e4dd190",
+              "overhead": "0x0",
+              "scalar": "0x100000000000000000000000000000000000000000000000000000000013880",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xf1c911e0c1e6dd08c8a7c80c9890e2037e0504c6",
+            "L1CrossDomainMessengerProxy": "0x825c858149f1e775a0f4aeb172037b970be7b736",
+            "L1Erc721BridgeProxy": "0x00bd00c5c7f60e222d9cb8040270ba929241a280",
+            "L1StandardBridgeProxy": "0xe639919b92ab6dd238aeacc6f2a8d6e355d17bd5",
+            "L2OutputOracleProxy": "0xdbf381984c4515fe3285d3c55fdfb3054c52c261",
+            "OptimismMintableErc20FactoryProxy": "0xa74b7baf04867e62b7824268e96144e503a23666",
+            "OptimismPortalProxy": "0xd52ba64cbe1e3b44167f810622fbef36be24d95c",
+            "SystemConfigProxy": "0x72934d7aedc1a2d889ca89aaf064cd9455e64d00",
+            "ProxyAdmin": "0x7617f4a55d62b9ee49578d9c90593e58e607415f",
+            "AnchorStateRegistryProxy": "0x4daa22ec75406e8ea2c70610115850912a770a3a",
+            "DelayedWethProxy": "0xd015f61f3cb26560507d758a726c77d18bf849bb",
+            "DisputeGameFactoryProxy": "0xb52337f38747d6931f2976eea24a3f3f6b7cdea2",
+            "FaultDisputeGame": null,
+            "Mips": "0x2b0293a059a2715935fa9459c9f3a4dce2bc6331",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x4a7bd533be022e7a2911c3c61e7e11e7a32ee77d"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x49ec5bd8c9cc35ce26b87e534d2e36980621ddd2",
+            "ProxyAdminOwner": "0x03ec1c43434e2f910a2fb984906cd2470fdb39c8",
+            "Guardian": "0xa5822fb7e3fb516e518e2629e6786e93858e41f4",
+            "Challenger": "0x34faa77b4d1686e399c96def0de31d30572eaa9f",
+            "Proposer": "0x8c6f6580c846634c5da08c40ae308de23006a679",
+            "UnsafeBlockSigner": "0xa940a669dae672111fd02df597cf7de7cf758fad",
+            "BatchSubmitter": "0x5bef09f138921ef7985d83aab97da1db6e4dd190"
+          },
+          "GasPayingToken": "0xa2120b9e674d3fc3875f415a7df52e382f141225"
+        },
+        {
+          "Name": "Xterio Chain (ETH)",
+          "l2_chain_id": 2702128,
+          "PublicRPC": "https://xterio-eth.alt.technology/",
+          "SequencerRPC": "https://xterio-eth.alt.technology/",
+          "Explorer": "https://eth.xterscan.io/",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000293b30",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": null,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": {
+            "da_challenge_address": null,
+            "da_challenge_window": 3600,
+            "da_resolve_window": 3600
+          },
+          "genesis": {
+            "l1": {
+              "number": 19938395,
+              "hash": "0x813c7b630e1d98a36dc26653406746f020b4f699381c2dbccaf51ef6dfd29ac2"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xb99fa3b9c265fe5364ed7ee2aca78535aaffd04e7b21f40383ed19a1c6d1d63b"
+            },
+            "l2_time": 1716537431,
+            "system_config": {
+              "batcherAddress": "0x7d6251d49a102a330cfb46d132982781620700cb",
+              "overhead": "0xb4",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xbdf852e2cc26ea3c2dee7b493b1fc12da406175a",
+            "L1CrossDomainMessengerProxy": "0x702df90e92a6841c9013fae6d724ddfa8f141d5c",
+            "L1Erc721BridgeProxy": "0x28d56c3bbbe4807c19cc81e6d5207fb681c3726b",
+            "L1StandardBridgeProxy": "0x2ad84abd52050956acc9c490d024b821a59e3fb6",
+            "L2OutputOracleProxy": "0x5a0492d20d984ee904e46e6ff24572bc755abb28",
+            "OptimismMintableErc20FactoryProxy": "0x515a0c8b1d9574c65ea1924ecd767b1d9b6ac32f",
+            "OptimismPortalProxy": "0xbc2beda4ce7a1f40aa458322a33b44081b2f545a",
+            "SystemConfigProxy": "0x6e99cde188daafeecb6ed8ac28b98de4c8ee5d6c",
+            "ProxyAdmin": "0x9e48d6bbca781c23392ec459bfb3657c40a794a8",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": "0x0ece16401a80551345bb672f177f51a8755ff775",
+            "DisputeGameFactoryProxy": "0x443164f044d8840479234e00e7ad5bb06b85fc78",
+            "FaultDisputeGame": null,
+            "Mips": "0x253ddbb3549e0cefaaaa7f71be502c5b94771ddc",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x089a4754538b74ff63bc6abead7a95973ab03572"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xcf06c459ae59d4f47469bce535afc3485ce89dbf",
+            "ProxyAdminOwner": "0xff75bd7672b79f2562faf98d488bbb3db1cd1574",
+            "Guardian": "0xdf3700a9cf9c7506ca3b41e6ba991476677a8787",
+            "Challenger": "0xfa8d42bde52c2b8b05fe5eecbadea6cb698a0bc5",
+            "Proposer": "0x7d2f9b38866141bf090dd670a826f27ea2408ad4",
+            "UnsafeBlockSigner": "0xcbdd38ce74ba96f0ae3d2e608da96ec744c80a7e",
+            "BatchSubmitter": "0x7d6251d49a102a330cfb46d132982781620700cb"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Zora",
+          "l2_chain_id": 7777777,
+          "PublicRPC": "https://rpc.zora.energy",
+          "SequencerRPC": "https://rpc.zora.energy",
+          "Explorer": "https://explorer.zora.energy",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x6f54ca6f6ede96662024ffd61bfd18f3f4e34dff",
+          "hardfork_configuration": {
+            "canyon_time": 1704992401,
+            "delta_time": 1708560000,
+            "ecotone_time": 1710374401,
+            "fjord_time": 1720627201,
+            "granite_time": 1726070401,
+            "holocene_time": 1736445601,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 17473923,
+              "hash": "0xbdbd2847f7aa5f7cd1bd4c9f904057f4ba0b498c7e380199c01d240e3a41a84f"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x47555a45a1af8d4728ca337a1e48375a83919b1ea16591e070a07388b7364e29"
+            },
+            "l2_time": 1686693839,
+            "system_config": {
+              "batcherAddress": "0x625726c858dbf78c0125436c943bf4b4be9d9033",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xef8115f2733fb2033a7c756402fc1deaa56550ef",
+            "L1CrossDomainMessengerProxy": "0xdc40a14d9abd6f410226f1e6de71ae03441ca506",
+            "L1Erc721BridgeProxy": "0x83a4521a3573ca87f3a971b169c5a0e1d34481c3",
+            "L1StandardBridgeProxy": "0x3e2ea9b92b7e48a52296fd261dc26fd995284631",
+            "L2OutputOracleProxy": "0x9e6204f750cd866b299594e2ac9ea824e2e5f95c",
+            "OptimismMintableErc20FactoryProxy": "0xc52bc7344e24e39df1bf026fe05c4e6e23cfbcff",
+            "OptimismPortalProxy": "0x1a0ad011913a150f69f6a19df447a0cfd9551054",
+            "SystemConfigProxy": "0xa3cab0126d5f504b071b81a3e8a2bbbf17930d86",
+            "ProxyAdmin": "0xd4ef175b9e72caee9f1fe7660a6ec19009903b49",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xc72ae5c7cc9a332699305e29f68be66c73b60542",
+            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
+            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
+            "Challenger": "0xca4571b1ecbec86ea2e660d242c1c29fcb55dc72",
+            "Proposer": "0x48247032092e7b0ecf5def611ad89eaf3fc888dd",
+            "UnsafeBlockSigner": "0x3dc8dfd0709c835cad15a6a27e089ff4cf4c9228",
+            "BatchSubmitter": "0x625726c858dbf78c0125436c943bf4b4be9d9033"
+          },
+          "GasPayingToken": null
+        }
+      ]
+    },
+    {
+      "name": "sepolia",
+      "config": {
+        "name": "Sepolia",
+        "l1": {
+          "chain_id": 11155111,
+          "public_rpc": "https://ethereum-sepolia-rpc.publicnode.com",
+          "explorer": "https://sepolia.etherscan.io"
+        },
+        "protocol_versions_addr": "0x79add5713b383daa0a138d3c4780c7a1804a8090",
+        "superchain_config_addr": "0xc2be75506d5724086deb7245bd260cc9753911be",
+        "OPContractsManagerProxyAddr": null
+      },
+      "chains": [
+        {
+          "Name": "Ethernity Testnet",
+          "l2_chain_id": 233,
+          "PublicRPC": "https://testnet.ethernitychain.io",
+          "SequencerRPC": "https://testnet.ethernitychain.io",
+          "Explorer": "https://testnet.ernscan.io",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xff00000000000000000000000000000000000233",
+          "hardfork_configuration": {
+            "canyon_time": 1699981200,
+            "delta_time": 1703203200,
+            "ecotone_time": 1708534800,
+            "fjord_time": 1716998400,
+            "granite_time": 1723478400,
+            "holocene_time": 1732633200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6037466,
+              "hash": "0x2d9c0b883cfc901f509bd94953c283c477adc57c8a20e234029244e68f00142a"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x4715665848c513c54d71a3e60700743f2b37ec21df9b9d0b8eefee4c30cd557a"
+            },
+            "l2_time": 1717499232,
+            "system_config": {
+              "batcherAddress": "0x973a9e30d6d11355a459a69e7cbfba61c7627736",
+              "overhead": "0xbc",
+              "scalar": "0xf4240",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x2d34a143d7bead8f75479c841e3aabf6c4afdec8",
+            "L1CrossDomainMessengerProxy": "0x1c8b6a6f3e3612c79e62460a6e44c24d1eff2fda",
+            "L1Erc721BridgeProxy": "0xbf0d43e12ef74dc21917e1d6175702ad673e1283",
+            "L1StandardBridgeProxy": "0xfd1a12b7a04b13c031d8b075ba5b9080a2cf246f",
+            "L2OutputOracleProxy": "0x11118536f94bc7c98bbaf9194be13fc1987293cd",
+            "OptimismMintableErc20FactoryProxy": "0x0d085b528e1f9f48018b46f9ac3696f16b7007f9",
+            "OptimismPortalProxy": "0x1f24d471ef7291c7f97dbd2f76299b30d3e3b6e3",
+            "SystemConfigProxy": "0x7c957fec1f6b3d1024442e989cb08b8f2285686c",
+            "ProxyAdmin": "0x7ea23a9df2e3e491757a9ff6c32083a44be560e6",
+            "AnchorStateRegistryProxy": "0xb065b32927c3114c0e0df16d3887f4fd12ef7117",
+            "DelayedWethProxy": "0x21676d682f11f3e46cce1797b19205dda78f0f6c",
+            "DisputeGameFactoryProxy": "0x64d0bce6ed7c16cac7817f3597758e31afacd01b",
+            "FaultDisputeGame": null,
+            "Mips": "0xfed5edd40bfbefc99432bbb4f2cecd450c4c8675",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x4abd4d6d11c5d7ce392b2b0544e37314710f53c2"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x097955a7aa7966d55d781688aa1493493ab513af",
+            "ProxyAdminOwner": "0x5a19d3afd327bd01d390eb52c11c2a9a79bcfb32",
+            "Guardian": "0x097955a7aa7966d55d781688aa1493493ab513af",
+            "Challenger": "0x097955a7aa7966d55d781688aa1493493ab513af",
+            "Proposer": "0xbf1374d8c2e98074368326786343f1ade19d5ccd",
+            "UnsafeBlockSigner": "0xdb0c6821a033eb9dc152bb008f42ebad0eaddca3",
+            "BatchSubmitter": "0x973a9e30d6d11355a459a69e7cbfba61c7627736"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Binary Sepolia",
+          "l2_chain_id": 625,
+          "PublicRPC": "https://rpc.testnet.thebinaryholdings.com",
+          "SequencerRPC": "https://sequencer.rpc.bnry.testnet.zeeve.net",
+          "Explorer": "https://explorer.sepolia.thebinaryholdings.com",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000042069",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1723204838,
+            "granite_time": 1723545055,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6092340,
+              "hash": "0x8d457519705ad17cf812d7cd4cfe5726eca8249f9e5f40a1d19992b07c2521ce"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xf1c38d92222758e1ea0c9c7ae1f7f2dfd0e3e747609f1c2d5a41ecfc5e84aba9"
+            },
+            "l2_time": 1718195040,
+            "system_config": {
+              "batcherAddress": "0x9cf89f8cb7cc94c579426f967d9517cd2e9adf29",
+              "overhead": "0x0",
+              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xd1d82d6fc94962fe25912c181375352d4a10c6f0",
+            "L1CrossDomainMessengerProxy": "0x33dc556a5df0b8998dc2640c78e531ae1db7925d",
+            "L1Erc721BridgeProxy": "0x7c95eebea6f68875b4093d9c2211fd26067a808f",
+            "L1StandardBridgeProxy": "0x3b78c3b41b3e3fc6bdf0bd3060c9e2471401c098",
+            "L2OutputOracleProxy": "0xf3699f96cbdd3868b64352669805d96d1fb6431d",
+            "OptimismMintableErc20FactoryProxy": "0xd47e937d602ffba8597b4f042c7a49e1149392fc",
+            "OptimismPortalProxy": "0xfbed910ca54f013bfea67bd4dc836263bdd0b46c",
+            "SystemConfigProxy": "0x1a6d0312faaaca2bf818660f164450176c6205c9",
+            "ProxyAdmin": "0xf42cff60b92a151911d99f3ed36ba1266511fd43",
+            "AnchorStateRegistryProxy": "0xb86ec23019c6c3f2fbc38502d26b7009d2a300be",
+            "DelayedWethProxy": "0x017e8a21e37ae4bfc482170656b1ebf8390bf880",
+            "DisputeGameFactoryProxy": "0x096b38bdc80b5bf5b5fb4e1a75ae38bda520474a",
+            "FaultDisputeGame": null,
+            "Mips": "0xb51ffe0a519291cbc0080a4f497a2bb4ac0a1c04",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x029e58272e3b5f7b69aa4455473fcc8c8b8deac3"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xd7e60cd8fbea5142a207042c477e1359df5fa688",
+            "ProxyAdminOwner": "0x5a11a7a6ca68819c601a4136bfbdfba26d5f043e",
+            "Guardian": "0xd7e60cd8fbea5142a207042c477e1359df5fa688",
+            "Challenger": "0xd7e60cd8fbea5142a207042c477e1359df5fa688",
+            "Proposer": "0x6087ec0371c2950d018ec97d8a1573d412dfbdbe",
+            "UnsafeBlockSigner": "0x0f68fc933d50f719abfbd680f56c22277e2f307c",
+            "BatchSubmitter": "0x9cf89f8cb7cc94c579426f967d9517cd2e9adf29"
+          },
+          "GasPayingToken": "0x46d878bf7bf62ec542953cb89ac0bf58d991181e"
+        },
+        {
+          "Name": "Mode Testnet",
+          "l2_chain_id": 919,
+          "PublicRPC": "https://sepolia.mode.network",
+          "SequencerRPC": "https://sepolia.mode.network",
+          "Explorer": "https://sepolia.explorer.mode.network",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 1703203200,
+          "batch_inbox_address": "0xcddae6148da1e003c230e4527f9baedc8a204e7e",
+          "hardfork_configuration": {
+            "canyon_time": 1703203200,
+            "delta_time": 1703203200,
+            "ecotone_time": 1708534800,
+            "fjord_time": 1716998400,
+            "granite_time": 1723478400,
+            "holocene_time": 1732633200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 3778382,
+              "hash": "0x4370cafe528a1b8f2aaffc578094731daf69ff82fd9edc30d2d842d3763f3410"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x13c352562289a88ed33087a51b6b6c859a27709c8555c9def7cb9757c043acad"
+            },
+            "l2_time": 1687867932,
+            "system_config": {
+              "batcherAddress": "0x4e6bd53883107b063c502ddd49f9600dc51b3ddc",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x83d45725d6562d8cd717673d6bb4c67c07dc1905",
+            "L1CrossDomainMessengerProxy": "0xc19a60d9e8c27b9a43527c3283b4dd8edc8be15c",
+            "L1Erc721BridgeProxy": "0x015a8c2e0a5fed579dbb05fd290e413adc6fc24a",
+            "L1StandardBridgeProxy": "0xbc5c679879b2965296756cd959c3c739769995e2",
+            "L2OutputOracleProxy": "0x2634bd65ba27ab63811c74a63118acb312701bfa",
+            "OptimismMintableErc20FactoryProxy": "0x00f7ab8c72d32f55cff15e8901c2f9f2bf29a3c0",
+            "OptimismPortalProxy": "0x320e1580efff37e008f1c92700d1eba47c1b23fd",
+            "SystemConfigProxy": "0x15cd4f6e0ce3b4832b33cb9c6f6fe6fc246754c2",
+            "ProxyAdmin": "0xe7413127f29e050df65ac3fc9335f85bb10091ae",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
+            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
+            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
+            "Challenger": "0x45effbd799ab49122eeeab75b78d9c56a187f9a7",
+            "Proposer": "0xe9e08a478e3a773c1b5d59014a0fdb901e6d1d69",
+            "UnsafeBlockSigner": "0x93a14e6894eeb4ff6a373e1ad4f498c3a207afe4",
+            "BatchSubmitter": "0x4e6bd53883107b063c502ddd49f9600dc51b3ddc"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Unichain Sepolia Testnet",
+          "l2_chain_id": 1301,
+          "PublicRPC": "https://sepolia.unichain.org",
+          "SequencerRPC": "https://sepolia-sequencer.unichain.org",
+          "Explorer": "https://sepolia.uniscan.xyz",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 1734559200,
+          "batch_inbox_address": "0xff00000000000000000000000000000000001301",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 0,
+            "holocene_time": 1734559200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 1,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6728364,
+              "hash": "0x81719966c43c08d616a832331500633db68006f5e8c0b575a6faf1704ad350c0"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xb7fe0bc9f98ca03294ca0094ff9374cc3e64130b6ec85850d6e260191f48bfe7"
+            },
+            "l2_time": 1726852428,
+            "system_config": {
+              "batcherAddress": "0x4ab3387810ef500bfe05a49dc53a44c222cbab3e",
+              "overhead": "0x0",
+              "scalar": "0x10000000000000000000000000000000000000000000000000dbba0000007d0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xef1295ed471dfec101691b946fb6b4654e88f98a",
+            "L1CrossDomainMessengerProxy": "0x448a37330a60494e666f6dd60ad48d930aeba381",
+            "L1Erc721BridgeProxy": "0x4696b5e042755103fe558738bcd1ecee7a45ebfe",
+            "L1StandardBridgeProxy": "0xea58fca6849d79ead1f26608855c2d6407d54ce2",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": "0xdf7977c3005730329a160637e8cb9f1675a4d9be",
+            "OptimismPortalProxy": "0x0d83dab629f0e0f9d36c0cbc89b69a489f0751bd",
+            "SystemConfigProxy": "0xaee94b9ab7752d3f7704bde212c0c6a0b701571d",
+            "ProxyAdmin": "0x2bf403e5353a7a082ef6bb3ae2be3b866d8d3ea4",
+            "AnchorStateRegistryProxy": "0xf971f1b0d80eb769577135b490b913825bfcf00b",
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": "0xeff73e5aa3b9aec32c659aa3e00444d20a84394b",
+            "FaultDisputeGame": null,
+            "Mips": "0x1cec5b1954302f6faf45515145c72d7f7266546c",
+            "PermissionedDisputeGame": "0x2a82958845ddc647ce1d45f44a7038d6a2d363ac",
+            "PreimageOracle": "0xad0a6f4f1503048c34d90df845c37c876407355a"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xb6185370e3db2472ec7ec4a2826954d2d4923b9f",
+            "ProxyAdminOwner": "0xd363339ee47775888df411a163c586a8bdea9dbf",
+            "Guardian": "0xd032d9e1f3b3ca6362ec56fbc9d689565f759825",
+            "Challenger": "0x921d59f383e9b86b3161a356013b6f8b40cf43c4",
+            "Proposer": "0xa25b0ef1cc3ee12a0a167b5bf44db1a9c166474e",
+            "UnsafeBlockSigner": "0x565b71025ab4de80aca33c62e51439af56301493",
+            "BatchSubmitter": "0x4ab3387810ef500bfe05a49dc53a44c222cbab3e"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Metal L2 Testnet",
+          "l2_chain_id": 1740,
+          "PublicRPC": "https://testnet.rpc.metall2.com",
+          "SequencerRPC": "https://testnet.rpc.metall2.com",
+          "Explorer": "https://testnet.explorer.metall2.com",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 1708534800,
+          "batch_inbox_address": "0x24567b64a86a4c966655fba6502a93dfb701e316",
+          "hardfork_configuration": {
+            "canyon_time": 1708129622,
+            "delta_time": 1708385400,
+            "ecotone_time": 1708534800,
+            "fjord_time": 1716998400,
+            "granite_time": 1723478400,
+            "holocene_time": 1732633200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 5304030,
+              "hash": "0x6a10927c70985f75898c48235b620acb2a48e9c777a40022f9dbad1b0c96a9c1"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xd24cf8e46b189b0c128dab4e46168520e3a4cdd390b239e8cc1e5abd22a629ae"
+            },
+            "l2_time": 1708129620,
+            "system_config": {
+              "batcherAddress": "0xdb80eca386ac72a55510e33cf9cf7533e75916ee",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x394f844b9a0fc876935d1b0b791d9e94ad905e8b",
+            "L1CrossDomainMessengerProxy": "0x5d335aa7d93102110879e3b54985c5f08146091e",
+            "L1Erc721BridgeProxy": "0x5d6ce6917dbeeacf010c96bffdabe89e33a30309",
+            "L1StandardBridgeProxy": "0x21530aadf4dcfb9c477171400e40d4ef615868be",
+            "L2OutputOracleProxy": "0x75a6b961c8da942ee03ca641b09c322549f6fa98",
+            "OptimismMintableErc20FactoryProxy": "0x49ff2c4be882298e8ca7decd195c207c42b45f66",
+            "OptimismPortalProxy": "0x01d4dfc994878682811b2980653d03e589f093cb",
+            "SystemConfigProxy": "0x5d63a8dc2737ce771aa4a6510d063b6ba2c4f6f2",
+            "ProxyAdmin": "0xf7bc4b3a78c7dd8be9b69b3128eeb0d6776ce18a",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
+            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
+            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
+            "Challenger": "0x45effbd799ab49122eeeab75b78d9c56a187f9a7",
+            "Proposer": null,
+            "UnsafeBlockSigner": null,
+            "BatchSubmitter": "0xdb80eca386ac72a55510e33cf9cf7533e75916ee"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Soneium Testnet Minato",
+          "l2_chain_id": 1946,
+          "PublicRPC": "https://rpc.minato.soneium.org",
+          "SequencerRPC": "https://rpc.minato.soneium.org",
+          "Explorer": "https://soneium-minato.blockscout.com/",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 1734685200,
+          "batch_inbox_address": "0x00ca81e019a5312d404ae7fe8367d30de4c11365",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1730106000,
+            "granite_time": 1730106000,
+            "holocene_time": 1734685200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6465975,
+              "hash": "0x87e648e8d219737526cbcbc03dc914256d4f8e13ae13dc0a2ad377d831cd6473"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x7ec49d93fa8f47c00e98cc5965cd3903a8faa9238743d2eba0e0550ab4c45c43"
+            },
+            "l2_time": 1723194336,
+            "system_config": {
+              "batcherAddress": "0xf0ab0441c8f4b89b561ae685b98c6ad5175e0cab",
+              "overhead": "0x0",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x6e8a77673109783001150dfa770e6c662f473da9",
+            "L1CrossDomainMessengerProxy": "0x0184245d202724dc28a2b688952cb56c882c226f",
+            "L1Erc721BridgeProxy": "0x2bfb22cd534a462028771a1ca9d6240166e450c4",
+            "L1StandardBridgeProxy": "0x5f5a404a5edabcdd80db05e8e54a78c9ebf000c2",
+            "L2OutputOracleProxy": "0x710e5286c746ec38beeb7538d0146f60d27be343",
+            "OptimismMintableErc20FactoryProxy": "0x6069bc38c6185f2db0d161f08ec8d1657f6078df",
+            "OptimismPortalProxy": "0x65ea1489741a5d72ffdd8e6485b216bbdcc15af3",
+            "SystemConfigProxy": "0x4ca9608fef202216bc21d543798ec854539baad3",
+            "ProxyAdmin": "0xff9d236641962cebf9dbfb54e7b8e91f99f10db0",
+            "AnchorStateRegistryProxy": "0xa4abeba1612cf731843460791e1a925c84d0991c",
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": "0xb3ad2c38e6e0640d7ce6aa952ab3a60e81bf7a01",
+            "FaultDisputeGame": null,
+            "Mips": "0x4e3db3fa21566ff2ad6e11d1adc129ecf649e47f",
+            "PermissionedDisputeGame": "0x55bc868c07c8cd48446a76966894f4d87844839c",
+            "PreimageOracle": "0xbfebcf9b8855c3e1d01b2ad28db9f59bc6cb6965"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xb278818732e5bebb742dc4aa0617ccd1dec76b65",
+            "ProxyAdminOwner": "0x4d59ccca765e1211bd32aa6f2a037fd37e519a25",
+            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
+            "Challenger": "0xb278818732e5bebb742dc4aa0617ccd1dec76b65",
+            "Proposer": "0xa759a2c80ec4c6421829862da30dd34436114502",
+            "UnsafeBlockSigner": "0x55930859cd7003f32a2ba171297408476532e535",
+            "BatchSubmitter": "0xf0ab0441c8f4b89b561ae685b98c6ad5175e0cab"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Lisk Sepolia Testnet",
+          "l2_chain_id": 4202,
+          "PublicRPC": "https://rpc.sepolia-api.lisk.com",
+          "SequencerRPC": "https://rpc.sepolia-api.lisk.com",
+          "Explorer": "https://sepolia-blockscout.lisk.com",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000004202",
+          "hardfork_configuration": {
+            "canyon_time": 1705312994,
+            "delta_time": 1705312994,
+            "ecotone_time": 1708534800,
+            "fjord_time": 1716998400,
+            "granite_time": 1723478400,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0xa",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 5089851,
+              "hash": "0x7d9d6dcec39efe182119f41b1bd2aa7b35b82e43927522afea86d210a4eace4b"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xead3e6ddd08ae7e27fd952b74ceb468ba889047ac96b351dd13bd55e5faf3372"
+            },
+            "l2_time": 1705312992,
+            "system_config": {
+              "batcherAddress": "0x246e119a5bcc2875161b23e4e602e25cece96e37",
+              "overhead": "0x834",
+              "scalar": "0xf4240",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x27bb4a7cd8fb20cb816bf4aac668bf841bb3d5d3",
+            "L1CrossDomainMessengerProxy": "0x857824e6234f7733eca4e9a76804fd1afa1a3a2c",
+            "L1Erc721BridgeProxy": "0xb4e988cf1ad8c361d56118437502a8f11c7faa01",
+            "L1StandardBridgeProxy": "0x1fb30e446ea791cd1f011675e5f3f5311b70faf5",
+            "L2OutputOracleProxy": "0xa0e35f56c318de1bd5d9ca6a94fe7e37c5663348",
+            "OptimismMintableErc20FactoryProxy": "0x269d632c1e518a922c30c749cfd3f82eb5c779b0",
+            "OptimismPortalProxy": "0xe3d90f21490686ec7ef37be788e02dfc12787264",
+            "SystemConfigProxy": "0xf54791059df4a12ba461b881b4080ae81a1d0ac0",
+            "ProxyAdmin": "0x5db9f05921d8d5a6a157f6f49c411cc0e46c6330",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": "0x9aa3890a87e6bd2cb85dad1a5d8b0a9d669e658a",
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x19de6d30bf43654b7244b8ada135e1aa639bf091",
+            "ProxyAdminOwner": "0x465874903125f26316c730ae84862606a3326ca5",
+            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
+            "Challenger": "0x19de6d30bf43654b7244b8ada135e1aa639bf091",
+            "Proposer": "0xbbd3a1d90b0ef416581acdc6a72046b38d3af9ad",
+            "UnsafeBlockSigner": "0x99804980804e9ebe78db89c049ffe36ceaaef654",
+            "BatchSubmitter": "0x246e119a5bcc2875161b23e4e602e25cece96e37"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "World Chain Sepolia Testnet",
+          "l2_chain_id": 4801,
+          "PublicRPC": "https://worldchain-sepolia.g.alchemy.com/public",
+          "SequencerRPC": "https://worldchain-sepolia-sequencer.g.alchemy.com",
+          "Explorer": "https://worldchain-sepolia.explorer.alchemy.com/",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000484752",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1721739600,
+            "granite_time": 1726570800,
+            "holocene_time": 1737633600,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0xa",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6278018,
+              "hash": "0xd220bbdf24df6d1611f4ece1d08c64feae914ce6299ab2806c864e30a5289201"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xf1deb67ee953f94d8545d2647918687fa8ba1f30fa6103771f11b7c483984070"
+            },
+            "l2_time": 1720547424,
+            "system_config": {
+              "batcherAddress": "0x0f3ff4731d7a10b89ed79ad1fd97844d7f66b96d",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 100000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0xc50ba0767a1c0ef69cf1d9cd44de52b08589f691",
+            "L1CrossDomainMessengerProxy": "0x7768c821200554d8f359a8902905ba9ede5659a9",
+            "L1Erc721BridgeProxy": "0x3580505c56f8560e3777e92fb27f70fd20c5b493",
+            "L1StandardBridgeProxy": "0xd7df54b3989855eb66497301a4aaec33dbb3f8de",
+            "L2OutputOracleProxy": "0xc8886f8bab6eaeb215adb5f1c686bf699248300e",
+            "OptimismMintableErc20FactoryProxy": "0x2d272ef54ee8ef5c2ff3523559186580b158cd57",
+            "OptimismPortalProxy": "0xff6eba109271fe6d4237eeed4bab1dd9a77dd1a4",
+            "SystemConfigProxy": "0x166f9406e79a656f12f05247fb8f5dfa6155bcbf",
+            "ProxyAdmin": "0x3a987fe1cb587b0a1808cf9bb7cbe0e341838319",
+            "AnchorStateRegistryProxy": "0x1333d5e5201d760444a399e77b3d337ebdb0dd07",
+            "DelayedWethProxy": "0x4f4b8adf1af4b61bb62f68b7af1c37f8a6311663",
+            "DisputeGameFactoryProxy": "0x8ec1111f67dad6b6a93b3f42dfbc92d81c98449a",
+            "FaultDisputeGame": null,
+            "Mips": "0x69470d6970cd2a006b84b1d4d70179c892cfce01",
+            "PermissionedDisputeGame": "0x552334bf0b124bd89bff744f33ca7e49d44a80ac",
+            "PreimageOracle": "0x92240135b46fc1142da181f550ae8f595b858854"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xe78a0a96c5d6ae6c606418ed4a9ced378cb030a0",
+            "ProxyAdminOwner": "0x945185c01fb641ba3e63a9bdf66575e35a407837",
+            "Guardian": "0xe78a0a96c5d6ae6c606418ed4a9ced378cb030a0",
+            "Challenger": "0x945185c01fb641ba3e63a9bdf66575e35a407837",
+            "Proposer": "0x77a95104e4025fc8b88a6a0f5fb7fae20851e414",
+            "UnsafeBlockSigner": "0x3241a7d28ea74e807a5087ba637fb58d8ddcd078",
+            "BatchSubmitter": "0x0f3ff4731d7a10b89ed79ad1fd97844d7f66b96d"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "RACE Testnet",
+          "l2_chain_id": 6806,
+          "PublicRPC": "https://racetestnet.io",
+          "SequencerRPC": "https://racetestnet.io",
+          "Explorer": "https://testnet.racescan.io/",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000006806",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": null,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6210400,
+              "hash": "0x28dd1dd74080560ef0b02f8f1ae31d1be75b01a70a5be6ef22e673cec538770f"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x994d67464c3368b8eb6f9770087399486b25d721a1868b95bb37de327b49ab89"
+            },
+            "l2_time": 1719646560,
+            "system_config": {
+              "batcherAddress": "0x584d61a30c7ef1e8d547ee02099dadc487f49889",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x1b573db1000ea419b6de8eb482c6d394179bd1a3",
+            "L1CrossDomainMessengerProxy": "0xdaeab17598938a4f27e50ac771249ad7df12ea7d",
+            "L1Erc721BridgeProxy": "0xbafb1a6e54e7750af29489d65888d1c96dfd66df",
+            "L1StandardBridgeProxy": "0x289179e9d43a35d47239456251f9c2fdbf9fbea2",
+            "L2OutputOracleProxy": "0xccac2b8ffc4f778242105f3a9e6b3ae3f827fc6a",
+            "OptimismMintableErc20FactoryProxy": "0xbd023e7f08ae0274dced397d4b6630d697ac738a",
+            "OptimismPortalProxy": "0xf2891fc6819cdd6bd9221874619bb03a6277d72a",
+            "SystemConfigProxy": "0x07e7a3f25aa73da15bc19b71fef8f5511342a409",
+            "ProxyAdmin": "0x4a0e8415e3eb85e7393445fd8e588283b62216c8",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xe6869af6c871614df04902870bb13d4505e1586c",
+            "ProxyAdminOwner": "0xac78e9b3aa9373ae4be2ba5bc9f716d7a746a65e",
+            "Guardian": "0xe6869af6c871614df04902870bb13d4505e1586c",
+            "Challenger": "0xe6869af6c871614df04902870bb13d4505e1586c",
+            "Proposer": "0x5a145e3f466fd6cc095214c700359df7894bad21",
+            "UnsafeBlockSigner": "0x89ea88ef4ac23f4c7fdc611fc9cd1c50df702c2c",
+            "BatchSubmitter": "0x584d61a30c7ef1e8d547ee02099dadc487f49889"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "arena-z-testnet",
+          "l2_chain_id": 9897,
+          "PublicRPC": "https://rpc.arena-z.t.raas.gelato.cloud",
+          "SequencerRPC": "https://rpc.arena-z.t.raas.gelato.cloud",
+          "Explorer": "https://arena-z.blockscout.com",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000009897",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 1723478400,
+            "holocene_time": 1732633200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0xa",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6410228,
+              "hash": "0x0c9c133c27d12e35a7b3ff2358f2dc1ff5eda8cced373dccb6cf394302bfd135"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xbd3f64b71ff2f6a414afa77068e602b764c45fe399b72de992af2a7787e8227d"
+            },
+            "l2_time": 1722432480,
+            "system_config": {
+              "batcherAddress": "0xabecfbb176fa579ee7e1ed1947e375b118433be0",
+              "overhead": "0xbc",
+              "scalar": "0xf4240",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x5b7996f61650a6f4920f2c8ef4bfaf4f64a07638",
+            "L1CrossDomainMessengerProxy": "0xcc226a3b7b5ec4d4d698418fc2c0492950136ba7",
+            "L1Erc721BridgeProxy": "0x11d7f6f2e59fc12e61dbfafe7790e54cab01b434",
+            "L1StandardBridgeProxy": "0x76a4b2cc5d210729fb3de13cee250663bdac73a6",
+            "L2OutputOracleProxy": "0xf2574585ec7ba515fd86402b84a60d5efb51b0ff",
+            "OptimismMintableErc20FactoryProxy": "0x88404b147e158e65fe7c9e7a9f50dd278f5e5e6e",
+            "OptimismPortalProxy": "0x2188047ad28b78d975ce319dfcda5d06c2a6a68b",
+            "SystemConfigProxy": "0xa3c900d30ee6e906fc085633258d2fe619680884",
+            "ProxyAdmin": "0x554d3431cf89e680610cfbfb9b558777e0a72f39",
+            "AnchorStateRegistryProxy": "0xbb5b16c3ffdb21f67b1d7b1158517ce62d95aa68",
+            "DelayedWethProxy": "0x8a91337fd5113669cc368f2b9d5aed8f6c4458c9",
+            "DisputeGameFactoryProxy": "0xd9e9933cc6ef672c93d2a42494b0d2bf14c05544",
+            "FaultDisputeGame": null,
+            "Mips": "0x379094d2ed496ca4ffaf1b17ad4ba3e152fb8486",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x0e4371a13e53563f7a635380cf2db6ecd620f444"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x776bee5229eb00349d6fc956efad7985ee36804d",
+            "ProxyAdminOwner": "0xb33c6a58c26666f04054e8b0d939e17d6eb1a155",
+            "Guardian": "0x776bee5229eb00349d6fc956efad7985ee36804d",
+            "Challenger": "0x776bee5229eb00349d6fc956efad7985ee36804d",
+            "Proposer": "0xbf80c17ee655837e25208436ed543217899b4bd8",
+            "UnsafeBlockSigner": "0xbbc751e8a6285f22c8b6305d1158071f204dbca4",
+            "BatchSubmitter": "0xabecfbb176fa579ee7e1ed1947e375b118433be0"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Shape Sepolia Testnet",
+          "l2_chain_id": 11011,
+          "PublicRPC": "https://sepolia.shape.network/",
+          "SequencerRPC": "https://shape-sepolia-sequencer.g.alchemy.com",
+          "Explorer": "https://shape-sepolia.explorer.alchemy.com/",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000011011",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 1721732400,
+            "granite_time": 1727197200,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 1800,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6151675,
+              "hash": "0x0e1156bae935f43af44f8d3e011275b8aeab57acd83cbd71d92903d3c9b29cf3"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xcb3558db049390808cbde6b82a48d06ed98d3fe959e088ac20ae56174595cfce"
+            },
+            "l2_time": 1718936160,
+            "system_config": {
+              "batcherAddress": "0x6ff556fa7cafec55ae77c5c1d58a010be75f9991",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x42721d8512d62aa26b2cfa1ae18beed5a9ab1337",
+            "L1CrossDomainMessengerProxy": "0xf9f730650e1ab4d23e2ac983934271ca7c5ef293",
+            "L1Erc721BridgeProxy": "0x19f02c55254d2644ef94f30c74a932d64e1d4f86",
+            "L1StandardBridgeProxy": "0x341ab1dafdfb73b3d6d075ef10b29e3cacb2a653",
+            "L2OutputOracleProxy": "0x532ddced3440eab81c529ac8b0d7e429b5c05c52",
+            "OptimismMintableErc20FactoryProxy": "0x46085e2e648488e49fbeaf6544b8e9dc96df8bdd",
+            "OptimismPortalProxy": "0xff8ca2b4d8122e41441f7ccdcf61b8692198bd1e",
+            "SystemConfigProxy": "0xa1ac91ed91ebe40e00d61e233c8026318b4da5fb",
+            "ProxyAdmin": "0xd60a706bf6108f090d055787b9b353fa7eee1355",
+            "AnchorStateRegistryProxy": "0x41ea3c370896632121cdde1b94a4eccf23da4532",
+            "DelayedWethProxy": "0x7cc9ca91ba4f92f4c967e93a1aad97beb18d3877",
+            "DisputeGameFactoryProxy": "0x93eaa7a1e7d7af7ed9d612f9957988c8631c33e8",
+            "FaultDisputeGame": null,
+            "Mips": "0xacf1ed7357e41f652407ae6cfe1024705c758c38",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x8f3b1c59ed4439ebf564604aa4b93130da4cd1d5"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xa9abe4af69bea2f381ca600f625eb3e6b7559266",
+            "ProxyAdminOwner": "0x4c4526c8c55c4e1a6f2aaf91e37f07c97786e0f5",
+            "Guardian": "0xa9abe4af69bea2f381ca600f625eb3e6b7559266",
+            "Challenger": "0xa9abe4af69bea2f381ca600f625eb3e6b7559266",
+            "Proposer": "0xf8ed03b83c15aa3d0b52095f3c9971225948b777",
+            "UnsafeBlockSigner": "0xbb4f4b3a46361653be9db255d8ff2d004f0fb248",
+            "BatchSubmitter": "0x6ff556fa7cafec55ae77c5c1d58a010be75f9991"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Pivotal Sepolia",
+          "l2_chain_id": 16481,
+          "PublicRPC": "https://sepolia.pivotalprotocol.com/",
+          "SequencerRPC": "https://sepolia.pivotalprotocol.com/",
+          "Explorer": "https://sepolia.pivotalscan.org/",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff000000000000000000000b0000000000016481",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": null,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6548454,
+              "hash": "0x416fb0d9f67e3b0e9701c6bfcb03a13732ddb397158fa8c2ed6e53a33c10995c"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xac7379723e9ff584c00e1cbeb20e76c36dbc98dc8bf2146d1df317b7b6636b91"
+            },
+            "l2_time": 1724315616,
+            "system_config": {
+              "batcherAddress": "0xc122b4d47644bbd7a98e41dd242d20054a11f720",
+              "overhead": "0x0",
+              "scalar": "0xf4240",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x40601f9c44ec842e3faa45cad15d475b450d9277",
+            "L1CrossDomainMessengerProxy": "0x1f6393c113b9c221fbcfb17c163c88d4bda172b0",
+            "L1Erc721BridgeProxy": "0x079ba88edd1be4fefb5011b61714df9ef092ad8f",
+            "L1StandardBridgeProxy": "0x788de2b0dd35808a05eaff7aaf5578b21e0dd9a7",
+            "L2OutputOracleProxy": "0x8a5f3b0897d9b9ba09fd2974f3abe038c15aaba9",
+            "OptimismMintableErc20FactoryProxy": "0x9aee2cf874fe76bf91cd63722db45212be48c5e3",
+            "OptimismPortalProxy": "0x923b28e0037a799a1e60368e60c92dffba982162",
+            "SystemConfigProxy": "0x5c72ce6ea707037bc476da8f4f969bc1f8abc78b",
+            "ProxyAdmin": "0xd79bd9c4a711d053c7f2e62526e3c4442b6b526f",
+            "AnchorStateRegistryProxy": "0x76b5568b3fe823c8d4dbb1d64e055f9e8d847fab",
+            "DelayedWethProxy": "0xe446ecee5bd4102f6366ef3551906adc40f3fc2a",
+            "DisputeGameFactoryProxy": "0xcb97c9224af16c95b8d8959a2752ef1832eb8ba9",
+            "FaultDisputeGame": null,
+            "Mips": "0x183a472b3e8724d4309895c8f1615ad49b6cc469",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0xb3aab329abb207583659e2546e9f24f32ea668e1"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xc121e7f785ac0e5b1da6c7316326412d1c4eb28c",
+            "ProxyAdminOwner": "0x1d60661f40acc64e38fcade8979d22a9b9278e6e",
+            "Guardian": "0xc121e7f785ac0e5b1da6c7316326412d1c4eb28c",
+            "Challenger": "0xc121e7f785ac0e5b1da6c7316326412d1c4eb28c",
+            "Proposer": "0xc12309aac4bd25dbf7df460fddd93f621ee5da3b",
+            "UnsafeBlockSigner": "0xc120bd1178485def5f761f85a4a393200a0aefd6",
+            "BatchSubmitter": "0xc122b4d47644bbd7a98e41dd242d20054a11f720"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Creator Chain Testnet",
+          "l2_chain_id": 66665,
+          "PublicRPC": "https://rpc.creatorchain.io",
+          "SequencerRPC": "https://rpc.creatorchain.io",
+          "Explorer": "https://explorer.creatorchain.io",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xfa5c2402828228a8dd700ba1e71f5e1128876fa8",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": 0,
+            "granite_time": 1723478400,
+            "holocene_time": 1732633200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6576576,
+              "hash": "0xe84d982c811eafc34801b0fdab8249739495ada50d119a58128aae583a801529"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x218eeee63576977ed59d751a04ef53ac7ecf6c053331a6f10672c38d211957ed"
+            },
+            "l2_time": 1724698536,
+            "system_config": {
+              "batcherAddress": "0xa488310ab2f8aa3294903930023bcab5880cb1ba",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x35236af82c775965183a7b9cf94fe8bf5665b072",
+            "L1CrossDomainMessengerProxy": "0x19f3d95a281f9cf6aa2c6e8b7ca7c6be83e41f3a",
+            "L1Erc721BridgeProxy": "0xe82526042dae3f8800f87232b5146ed4012ee426",
+            "L1StandardBridgeProxy": "0x78558fd5c8dc65d10753f004bfc4cfa8e199c668",
+            "L2OutputOracleProxy": "0x54e9be93b9a1aca9c0293db7710d9d18273afe1d",
+            "OptimismMintableErc20FactoryProxy": "0xd33347f9c147304c27b9502f1ad93b556bd9df12",
+            "OptimismPortalProxy": "0x1cb215554f36f518791b2e7359a73c96bfcadf69",
+            "SystemConfigProxy": "0x978e8311a5a710ef6413aba3a6b89092ce4a58f5",
+            "ProxyAdmin": "0xb235b455edd534bcac6028f38029cc128b144582",
+            "AnchorStateRegistryProxy": "0x1c2b5dbdba4da7cbe669e73b7f18041e16ecb993",
+            "DelayedWethProxy": "0x77877c3a557457edc27c5f650ce2f4521585a3ec",
+            "DisputeGameFactoryProxy": "0x5eb3040aeebc69595b4bdc4ecb97323330f14517",
+            "FaultDisputeGame": null,
+            "Mips": "0x09fee86ee30d0cf86a8e48089f958c1c04fa5700",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x7328668bbe05eb322b208410652cd41a6bd07a83"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
+            "ProxyAdminOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
+            "Guardian": "0xa9ff930151130fd19da1f03e5077afb7c78f8503",
+            "Challenger": "0x45effbd799ab49122eeeab75b78d9c56a187f9a7",
+            "Proposer": "0x4c67831dba16b1e60cf8f626424082a62f1a2fe5",
+            "UnsafeBlockSigner": "0xc9ad1db6cb756414cda307705a1ee4308e9100ae",
+            "BatchSubmitter": "0xa488310ab2f8aa3294903930023bcab5880cb1ba"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Base Sepolia Testnet",
+          "l2_chain_id": 84532,
+          "PublicRPC": "https://sepolia.base.org",
+          "SequencerRPC": "https://sepolia-sequencer.base.org",
+          "Explorer": "https://sepolia-explorer.base.org",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": false,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xff00000000000000000000000000000000084532",
+          "hardfork_configuration": {
+            "canyon_time": 1699981200,
+            "delta_time": 1703203200,
+            "ecotone_time": 1708534800,
+            "fjord_time": 1716998400,
+            "granite_time": 1723478400,
+            "holocene_time": 1732633200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0xa",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 4370868,
+              "hash": "0xcac9a83291d4dec146d6f7f69ab2304f23f5be87b1789119a0c5b1e4482444ed"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"
+            },
+            "l2_time": 1695768288,
+            "system_config": {
+              "batcherAddress": "0x6cdebe940bc0f26850285caca097c11c33103e47",
+              "overhead": "0x834",
+              "scalar": "0xf4240",
+              "gasLimit": 25000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x709c2b8ef4a9fefc629a8a2c1af424dc5bd6ad1b",
+            "L1CrossDomainMessengerProxy": "0xc34855f4de64f1840e5686e64278da901e261f20",
+            "L1Erc721BridgeProxy": "0x21efd066e581fa55ef105170cc04d74386a09190",
+            "L1StandardBridgeProxy": "0xfd0bf71f60660e2f608ed56e1659c450eb113120",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": "0xb1efb9650ad6d0cc1ed3ac4a0b7f1d5732696d37",
+            "OptimismPortalProxy": "0x49f53e41452c74589e85ca1677426ba426459e85",
+            "SystemConfigProxy": "0xf272670eb55e895584501d564afeb048bed26194",
+            "ProxyAdmin": "0x0389e59aa0a41e4a413ae70f0008e76caa34b1f3",
+            "AnchorStateRegistryProxy": "0x4c8ba32a5dac2a720bb35cedb51d6b067d104205",
+            "DelayedWethProxy": "0x7698b262b7a534912c8366dd8a531672deec634e",
+            "DisputeGameFactoryProxy": "0xd6e6dbf4f7ea0ac412fd8b65ed297e64bb7a06e1",
+            "FaultDisputeGame": "0x8a9ba50a785c3868bef1fd4924b640a5e0ed54cf",
+            "Mips": "0xff760a87e41144b336e29b6d4582427debdb6dee",
+            "PermissionedDisputeGame": "0x593d20c4c69485b95d11507239be2c725ea2a6fd",
+            "PreimageOracle": "0x627f825cbd48c4102d36f287be71f4234426b9e4"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x0fe884546476ddd290ec46318785046ef68a0ba9",
+            "ProxyAdminOwner": "0x0fe884546476ddd290ec46318785046ef68a0ba9",
+            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
+            "Challenger": "0xda3037ff70ac92cd867c683bd807e5a484857405",
+            "Proposer": "0x037637067c1dbe6d2430616d8f54cb774daa5999",
+            "UnsafeBlockSigner": "0xb830b99c95ea32300039624cb567d324d4b1d83c",
+            "BatchSubmitter": "0xfc56e7272eebbba5bc6c544e159483c4a38f8ba3"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Ink Sepolia",
+          "l2_chain_id": 763373,
+          "PublicRPC": "https://rpc-gel-sepolia.inkonchain.com",
+          "SequencerRPC": "https://rpc-gel-sepolia.inkonchain.com",
+          "Explorer": "https://explorer-sepolia.inkonchain.com",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0x004de1914f4f17ac234f5a5bc8a4072a231d44bf",
+          "hardfork_configuration": {
+            "canyon_time": 1699981200,
+            "delta_time": 1703203200,
+            "ecotone_time": 1708534800,
+            "fjord_time": 1716998400,
+            "granite_time": 1723478400,
+            "holocene_time": 1732633200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 1,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 6880819,
+              "hash": "0x5fb818b4d3ba100eeb3347c508bca24752ee88f235120e108bd9ee5d1b2ae50b"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xe5fd5cf0be56af58ad5751b401410d6b7a09d830fa459789746a3d0dd1c79834"
+            },
+            "l2_time": 1729003296,
+            "system_config": {
+              "batcherAddress": "0x21e57c21530bc33f12ba96c9ddc135488365002f",
+              "overhead": "0x0",
+              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x3454f9df5e750f1383e58c1cb001401e7a4f3197",
+            "L1CrossDomainMessengerProxy": "0x9fe1d3523f5342535e6e7770ed09ed85dbc1acc2",
+            "L1Erc721BridgeProxy": "0xd1c901bbd7796546a7ba2492e0e199911fae68c7",
+            "L1StandardBridgeProxy": "0x33f60714bbd74d62b66d79213c348614de51901c",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": "0x686f782a749d1854f6fa3f948450f4c65c6674f0",
+            "OptimismPortalProxy": "0x5c1d29c6c9c8b0800692acc95d700bcb4966a1d7",
+            "SystemConfigProxy": "0x05c993e60179f28bf649a2bb5b00b5f4283bd525",
+            "ProxyAdmin": "0xd7db319a49362b2328cf417a934300cccb442c8d",
+            "AnchorStateRegistryProxy": "0x89126a987717207d4e990ed2e8880fd170dcea1a",
+            "DelayedWethProxy": "0x180ac451088b8f87006ab0ca98a01507e42ac456",
+            "DisputeGameFactoryProxy": "0x860e626c700af381133d9f4af31412a2d1db3d5d",
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": "0xa8808360f7bc16da81938e5c29400d18bea651c4",
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
+            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
+            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
+            "Challenger": "0xfd1d2e729ae8eee2e146c033bf4400fe75284301",
+            "Proposer": "0xb15d792e30c5b7f67cbe5fe9ba76685b537b4543",
+            "UnsafeBlockSigner": "0x43ec5732581d3fae18abb7ce34a796e111dbd1a0",
+            "BatchSubmitter": "0x21e57c21530bc33f12ba96c9ddc135488365002f"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Funki Sepolia Testnet",
+          "l2_chain_id": 3397901,
+          "PublicRPC": "https://funki-testnet.alt.technology",
+          "SequencerRPC": "https://funki-testnet.alt.technology",
+          "Explorer": "https://sepolia-sandbox.funkichain.com/",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff000000000000000000000000000000000084bb",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": null,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 28800,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "alt-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": {
+            "da_challenge_address": null,
+            "da_challenge_window": 1,
+            "da_resolve_window": 1
+          },
+          "genesis": {
+            "l1": {
+              "number": 5853286,
+              "hash": "0x6bc7182e10df2bf35d76362989e10e2c6799c4ceff2eb32741cb804dfab9dd06"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xcebbf8fc7d0fab412866fe1e7df73c721104550ec35e55d173064acb2c0aeac9"
+            },
+            "l2_time": 1715060436,
+            "system_config": {
+              "batcherAddress": "0xda19a4e4d1dbc69bacf13435f08f76ced9b3c245",
+              "overhead": "0xb4",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x6ecc4a306cd20f8041d63b3db8eca46b713cdecc",
+            "L1CrossDomainMessengerProxy": "0x6f82d895e223dde65da28a8bbd14f3ef79cbf3b8",
+            "L1Erc721BridgeProxy": "0x598d245ea85fbfbcece6c62232bbcab688d3f68b",
+            "L1StandardBridgeProxy": "0x1ba82f688ef3c5b4363ff667254ed4dc59e97477",
+            "L2OutputOracleProxy": "0xb25812386d1cb976b50de7387f5cbc10fec3f27c",
+            "OptimismMintableErc20FactoryProxy": "0x8ee8eb6b829c382ca395d35c40dcd2ef8ae57c68",
+            "OptimismPortalProxy": "0xcee7ef4ddf482447fe14c605ea94b37cbe87ca9d",
+            "SystemConfigProxy": "0xd6a01f1ef51d65f023433992a8f62feead35b172",
+            "ProxyAdmin": "0xb3e1f3ab2a22049cc155eba7089ea20a5eab99ca",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": "0x31d0d1d3fc27b3f174e544364e7bb836980162d1",
+            "DisputeGameFactoryProxy": "0xec7c6e35f4e5361d279d5fe7222f3f45a8a83352",
+            "FaultDisputeGame": null,
+            "Mips": "0x71483031c5d2927ea83807d5c88bd8eccfaf292d",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0x2de051316aad761a3ebd6ff008d714805bd02c56"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xcdaf106c5531fd27bf27536e4696e325de9f52b8",
+            "ProxyAdminOwner": "0x814973b1ec9eb9172996931de7bf1380bd64a824",
+            "Guardian": "0xdf3d6fa42fe4225e6a042c4ed191d7e5d8252e6f",
+            "Challenger": "0x542a7142093d536bf277fa3b0410883ac4e121dc",
+            "Proposer": "0x0b8aa7c355917016496e999a80f1737ef9c0c962",
+            "UnsafeBlockSigner": "0x5359050acb96c515562896ba71089487138e4bde",
+            "BatchSubmitter": "0xda19a4e4d1dbc69bacf13435f08f76ced9b3c245"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "OP Sepolia Testnet",
+          "l2_chain_id": 11155420,
+          "PublicRPC": "https://sepolia.optimism.io",
+          "SequencerRPC": "https://sepolia-sequencer.optimism.io",
+          "Explorer": "https://sepolia-optimistic.etherscan.io",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xff00000000000000000000000000000011155420",
+          "hardfork_configuration": {
+            "canyon_time": 1699981200,
+            "delta_time": 1703203200,
+            "ecotone_time": 1708534800,
+            "fjord_time": 1716998400,
+            "granite_time": 1723478400,
+            "holocene_time": 1732633200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 4071408,
+              "hash": "0x48f520cf4ddaf34c8336e6e490632ea3cf1e5e93b0b2bc6e917557e31845371b"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"
+            },
+            "l2_time": 1691802540,
+            "system_config": {
+              "batcherAddress": "0x8f23bb38f531600e5d8fddaaec41f13fab46e98c",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x9bfe9c5609311df1c011c47642253b78a4f33f4b",
+            "L1CrossDomainMessengerProxy": "0x58cc85b8d04ea49cc6dbd3cbffd00b4b8d6cb3ef",
+            "L1Erc721BridgeProxy": "0xd83e03d576d23c9aeab8cc44fa98d058d2176d1f",
+            "L1StandardBridgeProxy": "0xfbb0621e0b23b5478b630bd55a5f21f67730b0f1",
+            "L2OutputOracleProxy": null,
+            "OptimismMintableErc20FactoryProxy": "0x868d59ff9710159c2b330cc0fbdf57144dd7a13b",
+            "OptimismPortalProxy": "0x16fc5058f25648194471939df75cf27a2fdc48bc",
+            "SystemConfigProxy": "0x034edd2a225f7f429a63e0f1d2084b9e0a93b538",
+            "ProxyAdmin": "0x189abaaaa82dfc015a588a7dbad6f13b1d3485bc",
+            "AnchorStateRegistryProxy": "0x218cd9489199f321e1177b56385d333c5b598629",
+            "DelayedWethProxy": "0xcdfdc692a53b4ae9f81e0aebd26107da4a71db84",
+            "DisputeGameFactoryProxy": "0x05f9613adb30026ffd634f38e5c4dfd30a197fa1",
+            "FaultDisputeGame": "0xd9d616e4a03a8e7cc962396c9f8d4e3d306097d3",
+            "Mips": "0x47b0e34c1054009e696babaad56165e1e994144d",
+            "PermissionedDisputeGame": "0x98e3f752c7224f8322afa935a4caec3832bb25c9",
+            "PreimageOracle": "0x92240135b46fc1142da181f550ae8f595b858854"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0xfd1d2e729ae8eee2e146c033bf4400fe75284301",
+            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
+            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
+            "Challenger": "0xfd1d2e729ae8eee2e146c033bf4400fe75284301",
+            "Proposer": "0x49277ee36a024120ee218127354c4a3591dc90a9",
+            "UnsafeBlockSigner": "0x57cacbb0d30b01eb2462e5dc940c161aff3230d3",
+            "BatchSubmitter": "0x8f23bb38f531600e5d8fddaaec41f13fab46e98c"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Cyber Testnet",
+          "l2_chain_id": 111557560,
+          "PublicRPC": "https://rpc.testnet.cyber.co",
+          "SequencerRPC": "https://cyber.alt.technology/",
+          "Explorer": "https://testnet.cyberscan.co/",
+          "SuperchainLevel": 0,
+          "GovernedByOptimism": false,
+          "SuperchainTime": null,
+          "batch_inbox_address": "0xff00000000000000000000000000000000042069",
+          "hardfork_configuration": {
+            "canyon_time": 0,
+            "delta_time": 0,
+            "ecotone_time": 0,
+            "fjord_time": null,
+            "granite_time": null,
+            "holocene_time": null,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 10,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0xa",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 5488109,
+              "hash": "0x0ad7012996ee943369fe592424821845ab115e43a9bc5d4e17bf9493869f98e3"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0xd61aa9a43cba806375bec108aba488f00cf784a53a6e5164bc3ef9eb8b169eaf"
+            },
+            "l2_time": 1710470112,
+            "system_config": {
+              "batcherAddress": "0x90bb84339856530192cd002533cd7f1290fc5142",
+              "overhead": "0x834",
+              "scalar": "0xf4240",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x4e9874640d6a670b7f4c7a1370bc303bb46f360f",
+            "L1CrossDomainMessengerProxy": "0xb88ee11d822bec8055f19711458de8593e7117a3",
+            "L1Erc721BridgeProxy": "0x524e85d2b49497561c53efeb4b126aa63883b480",
+            "L1StandardBridgeProxy": "0xaa1bd6d4d8cfd37330a917bc678cb38befaf44e6",
+            "L2OutputOracleProxy": "0xd94ce9e4886a6dcebc7cf993f4b38f5276516643",
+            "OptimismMintableErc20FactoryProxy": "0xcfc893490072f14f19ed6df2b0d985f908acee50",
+            "OptimismPortalProxy": "0x06c9cadb0346c8e142fb8299cef3eb5120d4c9b6",
+            "SystemConfigProxy": "0x43b838aa237b27c4fc953e591594cebb1ca2817f",
+            "ProxyAdmin": "0x6fce62e16720be713e77c954d6f1e6bc8b8d9f48",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": "0x99f0f9b0e7b16b10042e0935ce34f2fcebbe13c1",
+            "FaultDisputeGame": null,
+            "Mips": "0xd0e6c40d8462466633baa2d24796d788a08b2e9f",
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": "0xcef1e04fd7413c4a7287df9099ac57eed48fb8f2"
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x66530799037b46913e52e9e0144d15ab6ed954f5",
+            "ProxyAdminOwner": "0x642a102cd63f039930f99b4657f41fd4ad7699d6",
+            "Guardian": "0x66530799037b46913e52e9e0144d15ab6ed954f5",
+            "Challenger": "0x66530799037b46913e52e9e0144d15ab6ed954f5",
+            "Proposer": "0x69ffd6a97141b632631ef7f56ccea6a36f02bd7f",
+            "UnsafeBlockSigner": "0xf6c6d69ad0ec617593bddae9702b3f912621c6fe",
+            "BatchSubmitter": "0x90bb84339856530192cd002533cd7f1290fc5142"
+          },
+          "GasPayingToken": null
+        },
+        {
+          "Name": "Zora Sepolia Testnet",
+          "l2_chain_id": 999999999,
+          "PublicRPC": "https://sepolia.rpc.zora.energy",
+          "SequencerRPC": "https://sepolia.rpc.zora.energy",
+          "Explorer": "https://sepolia.explorer.zora.energy",
+          "SuperchainLevel": 1,
+          "GovernedByOptimism": true,
+          "SuperchainTime": 0,
+          "batch_inbox_address": "0xcd734290e4bd0200dac631c7d4b9e8a33234e91f",
+          "hardfork_configuration": {
+            "canyon_time": 1699981200,
+            "delta_time": 1703203200,
+            "ecotone_time": 1708534800,
+            "fjord_time": 1716998400,
+            "granite_time": 1723478400,
+            "holocene_time": 1732633200,
+            "isthmus_time": null,
+            "interop_time": null
+          },
+          "block_time": 2,
+          "seq_window_size": 3600,
+          "max_sequencer_drift": 600,
+          "DataAvailabilityType": "eth-da",
+          "optimism": {
+            "eip1559Elasticity": "0x6",
+            "eip1559Denominator": "0x32",
+            "eip1559DenominatorCanyon": "0xfa"
+          },
+          "alt_da": null,
+          "genesis": {
+            "l1": {
+              "number": 4548041,
+              "hash": "0xf782446a2487d900addb5d466a8597c7c543b59fa9aaa154d413830238f8798a"
+            },
+            "l2": {
+              "number": 0,
+              "hash": "0x8b17d2d52564a5a90079d9c860e1386272579e87b17ea27a3868513f53facd74"
+            },
+            "l2_time": 1698080004,
+            "system_config": {
+              "batcherAddress": "0x3cd868e221a3be64b161d596a7482257a99d857f",
+              "overhead": "0xbc",
+              "scalar": "0xa6fe0",
+              "gasLimit": 30000000,
+              "baseFeeScalar": null,
+              "blobBaseFeeScalar": null,
+              "eip1559Denominator": null,
+              "eip1559Elasticity": null
+            }
+          },
+          "Addresses": {
+            "AddressManager": "0x27c9392144dfcb6dab113f737356c32435cd1d55",
+            "L1CrossDomainMessengerProxy": "0x1bdbc0ae22bec0c2f08b4dd836944b3e28fe9b7a",
+            "L1Erc721BridgeProxy": "0x16b0a4f451c4cb567703367e587e15ac108e4311",
+            "L1StandardBridgeProxy": "0x5376f1d543dcbb5bd416c56c189e4cb7399fcccb",
+            "L2OutputOracleProxy": "0x2615b481bd3e5a1c0c7ca3da1bdc663e8615ade9",
+            "OptimismMintableErc20FactoryProxy": "0x5f3bdd57f01e88ce2f88f00685d30d6eb51a187c",
+            "OptimismPortalProxy": "0xeffe2c6ca9ab797d418f0d91ea60807713f3536f",
+            "SystemConfigProxy": "0xb54c7bfc223058773cf9b739cc5bd4095184fb08",
+            "ProxyAdmin": "0xe17071f4c216eb189437fbdbcc16bb79c4efd9c2",
+            "AnchorStateRegistryProxy": null,
+            "DelayedWethProxy": null,
+            "DisputeGameFactoryProxy": null,
+            "FaultDisputeGame": null,
+            "Mips": null,
+            "PermissionedDisputeGame": null,
+            "PreimageOracle": null
+          },
+          "Roles": {
+            "SystemConfigOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
+            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
+            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
+            "Challenger": "0x45effbd799ab49122eeeab75b78d9c56a187f9a7",
+            "Proposer": "0xe8326a5839175de7f467e66d8bb443aa70da1c3e",
+            "UnsafeBlockSigner": "0x3609513933100689bd1f84782529a99239842344",
+            "BatchSubmitter": "0x3cd868e221a3be64b161d596a7482257a99d857f"
+          },
+          "GasPayingToken": null
+        }
+      ]
+    },
+    {
       "name": "sepolia-dev-0",
       "config": {
         "name": "Sepolia Dev 0",
@@ -173,3822 +3989,6 @@
             "BatchSubmitter": "0x7a43fd33e42054c965ee7175dd4590d2bdba79cb"
           },
           "GasPayingToken": null
-        }
-      ]
-    },
-    {
-      "name": "mainnet",
-      "config": {
-        "name": "Mainnet",
-        "l1": {
-          "chain_id": 1,
-          "public_rpc": "https://ethereum-rpc.publicnode.com",
-          "explorer": "https://etherscan.io"
-        },
-        "protocol_versions_addr": "0x8062abc286f5e7d9428a0ccb9abd71e50d93b935",
-        "superchain_config_addr": "0x95703e0982140d16f8eba6d158fccede42f04a4c",
-        "OPContractsManagerProxyAddr": null
-      },
-      "chains": [
-        {
-          "Name": "HashKey Chain",
-          "l2_chain_id": 177,
-          "PublicRPC": "https://mainnet.hsk.xyz",
-          "SequencerRPC": "https://hashkeychain-mainnet.alt.technology",
-          "Explorer": "https://explorer.hsk.xyz",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0x0004cb44c80b6fbf8ceb1d80af688c9f7c0b2ab5",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 0,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 1800,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 21414667,
-              "hash": "0x0b4540b35529055a65950aef56df1a8fe22144f453f3bbc521a1248a8edbf761"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xa96aea946b763641b616ce0c69f37e61d9cd0abd709ef13a6b833e67b76de208"
-            },
-            "l2_time": 1734347135,
-            "system_config": {
-              "batcherAddress": "0x9391791f7cb74f8bfda65edc0749efd964311b55",
-              "overhead": "0x0",
-              "scalar": "0x10000000000000000000000000000000000000000000000ffffffff01312d00",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x679a65ad62972ea3561f40a12e93cca6f79f35e6",
-            "L1CrossDomainMessengerProxy": "0x899f07862d3a03f70e07b7f01183934b485d2e97",
-            "L1Erc721BridgeProxy": "0xd4c83d93c6fae3e0804b785f9cf465be95449d04",
-            "L1StandardBridgeProxy": "0x2171e6d3b7964fa9654ce41da8a8ffaff2cc70be",
-            "L2OutputOracleProxy": "0x1c8d97e21f868f8b87fa9b16fc77d46d7b0b48a2",
-            "OptimismMintableErc20FactoryProxy": "0x0407af506d86bfa5e401099b2fc2355590638f19",
-            "OptimismPortalProxy": "0xe7aa79b59cac06f9706d896a047feb9d3bda8bd3",
-            "SystemConfigProxy": "0x43f8defe3e9286d152e91bb16a248808e7247198",
-            "ProxyAdmin": "0x7986ed289935a0f47fc434c00cde309fe2c51f1c",
-            "AnchorStateRegistryProxy": "0x4dec2aa521108d78d983c0c12656c6cf8631f2ed",
-            "DelayedWethProxy": "0xbb70d595147a141e268532bfef61a8c25054d26d",
-            "DisputeGameFactoryProxy": "0x04ec030f362ce5a0b5fe2d4b4219f287c2ebde50",
-            "FaultDisputeGame": null,
-            "Mips": "0x7447b25b91336127042cc6899b2c15668a1ab8ba",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x5b9bef4d8c36fb013c70d0a6f455807c6bd5270b"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x29fbda675fa5a07b621c2c1a6e3f874c14f612f3",
-            "ProxyAdminOwner": "0x441f31c4cdf772558d4ea31f3114de59ae145e7c",
-            "Guardian": "0xc7fcbe26c1db751d63869f72f782a56710f6be5a",
-            "Challenger": "0xfcf35cee40325db21c3dc5b45849251e78be47eb",
-            "Proposer": "0x66b8f8425ecb610239e79e3517fefddcf85af41a",
-            "UnsafeBlockSigner": "0xbc80de532cf87543aad3267cc8a4caa2813130e7",
-            "BatchSubmitter": "0x9391791f7cb74f8bfda65edc0749efd964311b55"
-          },
-          "GasPayingToken": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a"
-        },
-        {
-          "Name": "Lyra Chain",
-          "l2_chain_id": 957,
-          "PublicRPC": "https://rpc.lyra.finance",
-          "SequencerRPC": "https://rpc.lyra.finance",
-          "Explorer": "https://explorer.lyra.finance",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0x5f7f7f6db967f0ef10bda0678964dba185d16c50",
-          "hardfork_configuration": {
-            "canyon_time": 1704992401,
-            "delta_time": 1708560000,
-            "ecotone_time": 1710374401,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "alt-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 18574841,
-              "hash": "0x00b06b23108483a0b6af8ff726b5ed3f508b7986f72c12679b10d72c05839716"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x047f535b3da7ad4f96d353b5a439740b7591413daee0e2f27dd3aabb24581af2"
-            },
-            "l2_time": 1700021615,
-            "system_config": {
-              "batcherAddress": "0x14e4e97bdc195d399ad8e7fc14451c279fe04c8e",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xc845f9c4004eb35a8bde8ad89c4760a9c0e65cab",
-            "L1CrossDomainMessengerProxy": "0x5456f02c08e9a018e42c39b351328e5aa864174a",
-            "L1Erc721BridgeProxy": "0x6cc3268794c5d3e3d9d52adefc748b59d536cb22",
-            "L1StandardBridgeProxy": "0x61e44dc0dae6888b5a301887732217d5725b0bff",
-            "L2OutputOracleProxy": "0x1145e7848c8b64c6cab86fd6d378733385c5c3ba",
-            "OptimismMintableErc20FactoryProxy": "0x08dea366f26c25a08c8d1c3568ad07d1e587136d",
-            "OptimismPortalProxy": "0x85ea9c11cf3d4786027f7fd08f4406b15777e5f8",
-            "SystemConfigProxy": "0x0e4c4cdd01cecb01070e9fdfe7600871e4ae996e",
-            "ProxyAdmin": "0x35d5d43271548c984662d4879fbc8e041bc1ff93",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Guardian": "0x91f4be0c264fafa1fed75c4440910cba2cad98e8",
-            "Challenger": "0x91f4be0c264fafa1fed75c4440910cba2cad98e8",
-            "Proposer": "0x03e820562ffd2e0390787cad706eaf1ff98c2608",
-            "UnsafeBlockSigner": "0xb71b58ffe538628557433dbbfa08d45ee5a69b44",
-            "BatchSubmitter": "0x14e4e97bdc195d399ad8e7fc14451c279fe04c8e"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "World Chain",
-          "l2_chain_id": 480,
-          "PublicRPC": "https://worldchain-mainnet.g.alchemy.com/public",
-          "SequencerRPC": "https://worldchain-mainnet-sequencer.g.alchemy.com",
-          "Explorer": "https://worldchain-mainnet.explorer.alchemy.com/",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000000480",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1721826000,
-            "granite_time": 1727780400,
-            "holocene_time": 1738238400,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 1800,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0xa",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 20170118,
-              "hash": "0x793daed4743301e00143be5533cd1dce0a741519e9e9c96588a9ad7dbb4d8db4"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x70d316d2e0973b62332ba2e9768dd7854298d7ffe77f0409ffdb8d859f2d3fa3"
-            },
-            "l2_time": 1719335639,
-            "system_config": {
-              "batcherAddress": "0xdbbe3d8c2d2b22a2611c5a94a9a12c2fcd49eb29",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 100000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x5891090d5085679714cb0e62f74950a3c19146a8",
-            "L1CrossDomainMessengerProxy": "0xf931a81d18b1766d15695ffc7c1920a62b7e710a",
-            "L1Erc721BridgeProxy": "0x1df436afdb2fbb40f1fe8bed4fc89a0d0990a8e9",
-            "L1StandardBridgeProxy": "0x470458c91978d2d929704489ad730dc3e3001113",
-            "L2OutputOracleProxy": "0x19a6d1e9034596196295cf148509796978343c5d",
-            "OptimismMintableErc20FactoryProxy": "0x82cb528466cf22412d89bdbe9bcf04856790dd0e",
-            "OptimismPortalProxy": "0xd5ec14a83b7d95be1e2ac12523e2dee12cbeea6c",
-            "SystemConfigProxy": "0x6ab0777fd0e609ce58f939a7f70fe41f5aa6300a",
-            "ProxyAdmin": "0xd7405be7f3e63b094af6c7c23d5ee33fd82f872d",
-            "AnchorStateRegistryProxy": "0xd4d7a57dcc563756ded99e224e144a6bf0327099",
-            "DelayedWethProxy": "0xf9adf7c9502c5c60352c20a4d22683422dbd061f",
-            "DisputeGameFactoryProxy": "0x069c4c579671f8c120b1327a73217d01ea2ec5ea",
-            "FaultDisputeGame": null,
-            "Mips": "0x5fe03a12c1236f9c22cb6479778ddaa4bce6299c",
-            "PermissionedDisputeGame": "0x55e6125f946f3cb24fc3e07dd7242f96ce512bd9",
-            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xb2aa0c2c4fd6bfcbf699d4c787cd6cc0dc461a9d",
-            "ProxyAdminOwner": "0xa4fb12d15eb85dc9284a7df0adbc8b696edbbf1d",
-            "Guardian": "0xb2aa0c2c4fd6bfcbf699d4c787cd6cc0dc461a9d",
-            "Challenger": "0xa4fb12d15eb85dc9284a7df0adbc8b696edbbf1d",
-            "Proposer": "0x2307278fc8ab0005974a6ded2fa6d1187333a223",
-            "UnsafeBlockSigner": "0x2270d6ec8e760daa317dd978cfb98c8f144b1f3a",
-            "BatchSubmitter": "0xdbbe3d8c2d2b22a2611c5a94a9a12c2fcd49eb29"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Mint Mainnet",
-          "l2_chain_id": 185,
-          "PublicRPC": "https://rpc.mintchain.io",
-          "SequencerRPC": "https://rpc.mintchain.io",
-          "Explorer": "https://explorer.mintchain.io",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0x4e31448a098393727b786e25b54e59dca1b77fe1",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 19861561,
-              "hash": "0x12980bfeb6e787dc906b0a6ae000733f9909f6af2121bc78a77afb5ba77988a0"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x88441835ca2344ea384e6f73e3d6f921cdd304e5bd6dca15590217e3911c61a3"
-            },
-            "l2_time": 1715608931,
-            "system_config": {
-              "batcherAddress": "0x68bdfece01535090c8f3c27ec3b1ae97e83fa4aa",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xea4165c5cdca155779803a113d8391b741ba5228",
-            "L1CrossDomainMessengerProxy": "0xf80be9f7a74ab776b69d3f0dc5c08c39b3a0ba19",
-            "L1Erc721BridgeProxy": "0xc2c908f3226d9082130d8e48378cd2efb08b521d",
-            "L1StandardBridgeProxy": "0x2b3f201543adf73160ba42e1a5b7750024f30420",
-            "L2OutputOracleProxy": "0xb751a613f2db932c6cdef5048e6d2af05f9b98ed",
-            "OptimismMintableErc20FactoryProxy": "0xf02012065ef6121a2a59ea0c590f42803cf101ea",
-            "OptimismPortalProxy": "0x59625d1fe0eeb8114a4d13c863978f39b3471781",
-            "SystemConfigProxy": "0xc975862927797812371a9fb631f83f8f5e2240d5",
-            "ProxyAdmin": "0xc684075a7cc997aa2e72152c330bdac73feacbdf",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Guardian": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Challenger": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Proposer": "0x3d53df1e69a32f98dfccf23ccb689763e21a78ba",
-            "UnsafeBlockSigner": "0x41c4fae5e80b9a622d8968bcd3ebbcf1f93b30db",
-            "BatchSubmitter": "0x68bdfece01535090c8f3c27ec3b1ae97e83fa4aa"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "RACE Mainnet",
-          "l2_chain_id": 6805,
-          "PublicRPC": "https://racemainnet.io",
-          "SequencerRPC": "https://racemainnet.io",
-          "Explorer": "https://racescan.io/",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000006805",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": null,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 20260129,
-              "hash": "0xb6fd41e6c3515172c36d3912046264475eaad84c2c56e99d74f4abd1a75b63c9"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xa864791943836c37b40ea688f3853f2198afb683a3e168d48bfa76c9896e3e65"
-            },
-            "l2_time": 1720421591,
-            "system_config": {
-              "batcherAddress": "0x8cda8351236199af7532bad53d683ddd9b275d89",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x3d2bde87466cae97011702d2c305fd40eebbbf0a",
-            "L1CrossDomainMessengerProxy": "0xf54b2baef894cff5511a5722acaac0409f2f2d89",
-            "L1Erc721BridgeProxy": "0x0f33d824d74180598311b3025095727bea61f219",
-            "L1StandardBridgeProxy": "0x680969a6c58183987c8126ca4de6b59c6540cd2a",
-            "L2OutputOracleProxy": "0x8bf8442d49d52377d735a90f19657a29f29aa83c",
-            "OptimismMintableErc20FactoryProxy": "0x1d1c4c89ad5ff486c3c67e3dd84a22cf05420711",
-            "OptimismPortalProxy": "0x0485ca8a73682b3d3f5ae98cdca1e5b512e728e9",
-            "SystemConfigProxy": "0xcf6a32db8b3313b3d439ce6909511c2c3415fa32",
-            "ProxyAdmin": "0x9b3c6d1d33f1fd82ebb8dfbe38da162b329de191",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xbac1ad52745162c0aa3711fe88df1cc67034a3b9",
-            "ProxyAdminOwner": "0x5a669b2193718f189b0576c0cdcedfed6f40f9ea",
-            "Guardian": "0x2e7b9465b25c081c07274a31dbd05c6146f67961",
-            "Challenger": "0x2e7b9465b25c081c07274a31dbd05c6146f67961",
-            "Proposer": "0x88d58bfbcd70c25409b67117fc1cdfefda113a78",
-            "UnsafeBlockSigner": "0x9b5639d472d6764b70f5046ac0b13438718398e0",
-            "BatchSubmitter": "0x8cda8351236199af7532bad53d683ddd9b275d89"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Cyber Mainnet",
-          "l2_chain_id": 7560,
-          "PublicRPC": "https://rpc.cyber.co",
-          "SequencerRPC": "https://cyber.alt.technology/",
-          "Explorer": "https://cyberscan.co/",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000001d88",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": null,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "alt-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": {
-            "da_challenge_address": null,
-            "da_challenge_window": 3600,
-            "da_resolve_window": 3600
-          },
-          "genesis": {
-            "l1": {
-              "number": 19681125,
-              "hash": "0x8fa2a34b37420b863aa33da7661a8929af8bd7a436b9e612c727eb5e63da3879"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x0bbf36c47db3b42b40b2e6cadc183612337d1ac8602eb9e57071ae0043e70fc7"
-            },
-            "l2_time": 1713428567,
-            "system_config": {
-              "batcherAddress": "0xf0748c52edc23135d9845cdfb91279cf61ee14b4",
-              "overhead": "0xb4",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x19b5804b88f10262a55ac731f28a3bbc4209853a",
-            "L1CrossDomainMessengerProxy": "0x3c01ebf22e9c111528c1e027d68944edab08dfc9",
-            "L1Erc721BridgeProxy": "0x4f4b716627d2ba0439327ce8b563b4443af47dbd",
-            "L1StandardBridgeProxy": "0x12a580c05466eefb2c467c6b115844cdaf55b255",
-            "L2OutputOracleProxy": "0xa669a743b065828682ee16109273f5cfef5e676d",
-            "OptimismMintableErc20FactoryProxy": "0x51a00470eb50d758ecff3b96db0bf4a8e86268f4",
-            "OptimismPortalProxy": "0x1d59bc9fce6b8e2b1bf86d4777289ffd83d24c99",
-            "SystemConfigProxy": "0x5d1f4bbaf6d484fa9d5d9705f92de6063bff6055",
-            "ProxyAdmin": "0x7e54107731ec43e78da678dfa5fb6222ad036e03",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": "0x588dad44201885ff23068f1142e303d52d103919",
-            "DisputeGameFactoryProxy": "0xbf4676f21a7889e0fd61bcdc9b98e60b01c1b36f",
-            "FaultDisputeGame": null,
-            "Mips": "0x0048defca9f0da952cfd1ae9f8e962937d3e4143",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x0747ef2570e3dbf65f0a12b371f19ca4a66a8dde"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xc76c563185d01284adbc9cf5bb909162dd2f15e7",
-            "ProxyAdminOwner": "0xc2259e7fb719411f97abdcdf449f6ba3b9d75398",
-            "Guardian": "0x0c883f622b4ccbf1e8ce86217998f87e6d36bce4",
-            "Challenger": "0x87bd2cff3b59d615b1eac7a7f809b5e5f0ee6752",
-            "Proposer": "0xf2987f0a626c8d29dfb2e0a21144ca3026d6f1e1",
-            "UnsafeBlockSigner": "0xa7a4d6d5920b93d0fe590f9524ef17f24ee1f5b8",
-            "BatchSubmitter": "0xf0748c52edc23135d9845cdfb91279cf61ee14b4"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Mode",
-          "l2_chain_id": 34443,
-          "PublicRPC": "https://mainnet.mode.network",
-          "SequencerRPC": "https://mainnet-sequencer.mode.network",
-          "Explorer": "https://explorer.mode.network",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0x24e59d9d3bd73ccc28dc54062af7ef7bff58bd67",
-          "hardfork_configuration": {
-            "canyon_time": 1704992401,
-            "delta_time": 1708560000,
-            "ecotone_time": 1710374401,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 18586927,
-              "hash": "0xf9b1b22a7ef9d13f063ea467bcb70fb6e9f29698ecb7366a2cdf5af2165cacee"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xb0f682e12fc555fd5ce8fce51a59a67d66a5b46be28611a168260a549dac8a9b"
-            },
-            "l2_time": 1700167583,
-            "system_config": {
-              "batcherAddress": "0x99199a22125034c808ff20f377d91187e8050f2e",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x50ef494573f28cad6b64c31b7a00cdaa48306e15",
-            "L1CrossDomainMessengerProxy": "0x95bdca6c8edeb69c98bd5bd17660bacef1298a6f",
-            "L1Erc721BridgeProxy": "0x2901da832a4d0297ff0691100a8e496626cc626d",
-            "L1StandardBridgeProxy": "0x735adbbe72226bd52e818e7181953f42e3b0ff21",
-            "L2OutputOracleProxy": "0x4317ba146d4933d889518a3e5e11fe7a53199b04",
-            "OptimismMintableErc20FactoryProxy": "0x69216395a62dfb243c05ef4f1c27af8655096a95",
-            "OptimismPortalProxy": "0x8b34b14c7c7123459cf3076b8cb929be097d0c07",
-            "SystemConfigProxy": "0x5e6432f18bc5d497b1ab2288a025fbf9d69e2221",
-            "ProxyAdmin": "0x470d87b1dae09a454a43d1fd772a561a03276ab7",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
-            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
-            "Challenger": "0x309fe2536d01867018d120b40e4676723c53a14c",
-            "Proposer": "0x674f64d64ddc198db83cd9047df54bf89ccd0ddb",
-            "UnsafeBlockSigner": "0xa7fa9ca4ac88686a542c0f830d7378eab4a0278f",
-            "BatchSubmitter": "0x99199a22125034c808ff20f377d91187e8050f2e"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Funki",
-          "l2_chain_id": 33979,
-          "PublicRPC": "https://rpc-mainnet.funkichain.com",
-          "SequencerRPC": "https://rpc-mainnet.funkichain.com",
-          "Explorer": "https://funki.superscan.network",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000084bb84bb",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 8400,
-          "max_sequencer_drift": 1800,
-          "DataAvailabilityType": "alt-da",
-          "optimism": {
-            "eip1559Elasticity": "0xa",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": {
-            "da_challenge_address": null,
-            "da_challenge_window": 3600,
-            "da_resolve_window": 3600
-          },
-          "genesis": {
-            "l1": {
-              "number": 20325568,
-              "hash": "0xa0768467271297b618c4306469577fd14ba5b0c0488d6e9710a24762cbfe2928"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x7d2831dd811c616d073342a3074f2ce737c6b200b8192f9528e8bf32b1fac83e"
-            },
-            "l2_time": 1721211095,
-            "system_config": {
-              "batcherAddress": "0x73c98cf34af1f7d798e8e6f34b16037530bffc41",
-              "overhead": "0x0",
-              "scalar": "0x100000000000000000000000000000000000000000000000000000000003138",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x5a4ebf927338ea6af377caeee99c85088908f57d",
-            "L1CrossDomainMessengerProxy": "0x8f56a665c376a08b604dd32ee6e88667a6093172",
-            "L1Erc721BridgeProxy": "0x94519dd4ba8ba20aaad14f7c6cd00fa1bb0192e9",
-            "L1StandardBridgeProxy": "0xa2c1c1a473250094a6244f2bcf6cb51f670ad3ac",
-            "L2OutputOracleProxy": "0x1a9ae6486caec0504657351ac473b3df8a1367cb",
-            "OptimismMintableErc20FactoryProxy": "0x87e75dcc1bb4e5b42cb5c52eb5832d6ecc3bfef4",
-            "OptimismPortalProxy": "0x5c9c7f98ed153a2deaa981eb5c97b31744accf22",
-            "SystemConfigProxy": "0xd39a6cccfa23cb741bb530497e42ec337f1215a8",
-            "ProxyAdmin": "0xd069c4724f9bc15fa53b3b2516594512aef8c957",
-            "AnchorStateRegistryProxy": "0x48eb5a81cc3a8955d0dabd6eed45ac09c7c1889f",
-            "DelayedWethProxy": "0x7992352f723d1209cdd9b786def1fbd8dc6511db",
-            "DisputeGameFactoryProxy": "0x2dc9d2cb1ba0b8a46ae252ab4fbe1ad5c5c3b795",
-            "FaultDisputeGame": null,
-            "Mips": "0x29564d1b96a1308e6930f88665576763ed4837e2",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0xd8f66efec53cea76c597827ba5bf3f68d29f2fa8"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xc0ce2761d5cc92d25db6ccd95e4b9483ed22d11b",
-            "ProxyAdminOwner": "0x89cb6669f87c165e7128f4a57476ee4daa7ffbcd",
-            "Guardian": "0x052a8cd5967bc3bdb5660c989a3a68bca683a077",
-            "Challenger": "0x9f8b2470ffecbca2ffda20b9e10f6a12f33bc2ce",
-            "Proposer": "0x7a7690bbab496537ac59b45b4c59d789233bca16",
-            "UnsafeBlockSigner": "0x843458b6de651e02dfd5bffea0e9cfb3eca293ef",
-            "BatchSubmitter": "0x73c98cf34af1f7d798e8e6f34b16037530bffc41"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "BOB",
-          "l2_chain_id": 60808,
-          "PublicRPC": "https://rpc.gobob.xyz",
-          "SequencerRPC": "https://rpc.gobob.xyz",
-          "Explorer": "https://explorer.gobob.xyz",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0x3a75346f81302aac0333fb5dcdd407e12a6cfa83",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 19634321,
-              "hash": "0x218132178d65c4bc490aadd93c31535326043fe1fe8fea2d87f26c1da83d45c2"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x8ed4903b7f9c3f7bb7a09374d63ae9c9852cd9aab1784b433c41dbeb47b4dba2"
-            },
-            "l2_time": 1712861987,
-            "system_config": {
-              "batcherAddress": "0x08f9f14ff43e112b18c96f0986f28cb1878f1d11",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xf2dc77c697e892542cc53336178a78bb313dfdc7",
-            "L1CrossDomainMessengerProxy": "0xe3d981643b806fb8030cdb677d6e60892e547eda",
-            "L1Erc721BridgeProxy": "0x5ff93263d5181b2a826f8c51d54bc0da2d20d50a",
-            "L1StandardBridgeProxy": "0x3f6ce1b36e5120bbc59d0cfe8a5ac8b6464ac1f7",
-            "L2OutputOracleProxy": "0xdda53e23f8a32640b04d7256e651c1db98db11c1",
-            "OptimismMintableErc20FactoryProxy": "0x5557408ab14013ce9dbb300de0d87d386bb09cb6",
-            "OptimismPortalProxy": "0x8adee124447435fe03e3cd24df3f4cae32e65a3e",
-            "SystemConfigProxy": "0xacb886b75d76d1c8d9248cfddfa09b70c71c5393",
-            "ProxyAdmin": "0x0d9f416260598313be6fdf6b010f2fbc34957cd0",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xc91482a96e9c2a104d9298d1980eccf8c4dc764e",
-            "ProxyAdminOwner": "0xc91482a96e9c2a104d9298d1980eccf8c4dc764e",
-            "Guardian": "0xc91482a96e9c2a104d9298d1980eccf8c4dc764e",
-            "Challenger": "0xc91482a96e9c2a104d9298d1980eccf8c4dc764e",
-            "Proposer": "0x7cb1022d30b9860c36b243e7b181a1d46f618c69",
-            "UnsafeBlockSigner": "0xb18ad28cb78fd2eafac6941c24c5135515b796f0",
-            "BatchSubmitter": "0x08f9f14ff43e112b18c96f0986f28cb1878f1d11"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "OP Mainnet",
-          "l2_chain_id": 10,
-          "PublicRPC": "https://mainnet.optimism.io",
-          "SequencerRPC": "https://mainnet-sequencer.optimism.io",
-          "Explorer": "https://explorer.optimism.io",
-          "SuperchainLevel": 2,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xff00000000000000000000000000000000000010",
-          "hardfork_configuration": {
-            "canyon_time": 1704992401,
-            "delta_time": 1708560000,
-            "ecotone_time": 1710374401,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 17422590,
-              "hash": "0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"
-            },
-            "l2": {
-              "number": 105235063,
-              "hash": "0xdbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3"
-            },
-            "l2_time": 1686068903,
-            "system_config": {
-              "batcherAddress": "0x6887246668a3b87f54deb3b94ba47a6f63f32985",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xde1fcfb0851916ca5101820a69b13a4e276bd81f",
-            "L1CrossDomainMessengerProxy": "0x25ace71c97b33cc4729cf772ae268934f7ab5fa1",
-            "L1Erc721BridgeProxy": "0x5a7749f83b81b301cab5f48eb8516b986daef23d",
-            "L1StandardBridgeProxy": "0x99c9fc46f92e8a1c0dec1b1747d010903e884be1",
-            "L2OutputOracleProxy": null,
-            "OptimismMintableErc20FactoryProxy": "0x75505a97bd334e7bd3c476893285569c4136fa0f",
-            "OptimismPortalProxy": "0xbeb5fc579115071764c7423a4f12edde41f106ed",
-            "SystemConfigProxy": "0x229047fed2591dbec1ef1118d64f7af3db9eb290",
-            "ProxyAdmin": "0x543ba4aadbab8f9025686bd03993043599c6fb04",
-            "AnchorStateRegistryProxy": "0x18dac71c228d1c32c99489b7323d441e1175e443",
-            "DelayedWethProxy": "0x82511d494b5c942be57498a70fdd7184ee33b975",
-            "DisputeGameFactoryProxy": "0xe5965ab5962edc7477c8520243a95517cd252fa9",
-            "FaultDisputeGame": "0xa6f3dfdbf4855a43c529bc42ede96797252879af",
-            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
-            "PermissionedDisputeGame": "0x050ed6f6273c7d836a111e42153bc00d0380b87d",
-            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x847b5c174615b1b7fdf770882256e2d3e95b9d92",
-            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
-            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
-            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
-            "Proposer": "0x473300df21d047806a082244b417f96b32f13a33",
-            "UnsafeBlockSigner": "0xaaaa45d9549eda09e70937013520214382ffc4a2",
-            "BatchSubmitter": "0x6887246668a3b87f54deb3b94ba47a6f63f32985"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Base",
-          "l2_chain_id": 8453,
-          "PublicRPC": "https://mainnet.base.org",
-          "SequencerRPC": "https://mainnet-sequencer.base.org",
-          "Explorer": "https://explorer.base.org",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xff00000000000000000000000000000000008453",
-          "hardfork_configuration": {
-            "canyon_time": 1704992401,
-            "delta_time": 1708560000,
-            "ecotone_time": 1710374401,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 17481768,
-              "hash": "0x5c13d307623a926cd31415036c8b7fa14572f9dac64528e857a470511fc30771"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"
-            },
-            "l2_time": 1686789347,
-            "system_config": {
-              "batcherAddress": "0x5050f69a9786f081509234f1a7f4684b5e5b76c9",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x8efb6b5c4767b09dc9aa6af4eaa89f749522bae2",
-            "L1CrossDomainMessengerProxy": "0x866e82a600a1414e583f7f13623f1ac5d58b0afa",
-            "L1Erc721BridgeProxy": "0x608d94945a64503e642e6370ec598e519a2c1e53",
-            "L1StandardBridgeProxy": "0x3154cf16ccdb4c6d922629664174b904d80f2c35",
-            "L2OutputOracleProxy": "0x56315b90c40730925ec5485cf004d835058518a0",
-            "OptimismMintableErc20FactoryProxy": "0x05cc379ebd9b30bba19c6fa282ab29218ec61d84",
-            "OptimismPortalProxy": "0x49048044d57e1c92a77f79988d21fa8faf74e97e",
-            "SystemConfigProxy": "0x73a79fab69143498ed3712e519a88a918e1f4072",
-            "ProxyAdmin": "0x0475cbcaebd9ce8afa5025828d5b98dfb67e059e",
-            "AnchorStateRegistryProxy": "0xdb9091e48b1c42992a1213e6916184f9ebdbfedf",
-            "DelayedWethProxy": "0xa2f2ac6f5af72e494a227d79db20473cf7a1ffe8",
-            "DisputeGameFactoryProxy": "0x43edb88c4b80fdd2adff2412a7bebf9df42cb40e",
-            "FaultDisputeGame": "0xcd3c0194db74c23807d4b90a5181e1b28cf7007c",
-            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
-            "PermissionedDisputeGame": "0x19009debf8954b610f207d5925eede827805986e",
-            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x14536667cd30e52c0b458baaccb9fada7046e056",
-            "ProxyAdminOwner": "0x7bb41c3008b3f03fe483b28b8db90e19cf07595c",
-            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
-            "Challenger": "0x6f8c5ba3f59ea3e76300e3becdc231d656017824",
-            "Proposer": "0x642229f238fb9de03374be34b0ed8d9de80752c5",
-            "UnsafeBlockSigner": "0xaf6e19be0f9ce7f8afd49a1824851023a8249e8a",
-            "BatchSubmitter": "0x5050f69a9786f081509234f1a7f4684b5e5b76c9"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Redstone",
-          "l2_chain_id": 690,
-          "PublicRPC": "https://rpc.redstonechain.com",
-          "SequencerRPC": "https://rpc.redstonechain.com",
-          "Explorer": "https://explorer.redstone.xyz",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000000690",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": null,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "alt-da",
-          "optimism": {
-            "eip1559Elasticity": "0x2",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0x32"
-          },
-          "alt_da": {
-            "da_challenge_address": null,
-            "da_challenge_window": 3600,
-            "da_resolve_window": 3600
-          },
-          "genesis": {
-            "l1": {
-              "number": 19578374,
-              "hash": "0xb9ec694afdde2e2ed661ed8ec56dace5cf8723801342fa1229e693f2a98af672"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xa4f55631013577464810893a05b18f07fe483885a6ef93e0060e7128bdf4ca3b"
-            },
-            "l2_time": 1712185091,
-            "system_config": {
-              "batcherAddress": "0xa31cb9bc414601171d4537580f98f66c03aecd43",
-              "overhead": "0x1",
-              "scalar": "0x1def",
-              "gasLimit": 100000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xfe27f187a9e46104a932189ddf229871e06b22f8",
-            "L1CrossDomainMessengerProxy": "0x592c1299e0f8331d81a28c0fc7352da24edb444a",
-            "L1Erc721BridgeProxy": "0x4ffb98dbc3086ba85d5e626a6ebc3d0d08533ff4",
-            "L1StandardBridgeProxy": "0xc473ca7e02af24c129c2eef51f2adf0411c1df69",
-            "L2OutputOracleProxy": "0xa426a052f657aeeefc298b3b5c35a470e4739d69",
-            "OptimismMintableErc20FactoryProxy": "0x5f962474834cf1981df6232e4b6431d3d10cb71d",
-            "OptimismPortalProxy": "0xc7bcb0e8839a28a1cfadd1cf716de9016cda51ae",
-            "SystemConfigProxy": "0x8f2428f7189c0d92d1c4a5358903a8c80ec6a69d",
-            "ProxyAdmin": "0xcc53b447afe07926423ab96d5496b1af30485ed2",
-            "AnchorStateRegistryProxy": "0xc51ac31bcefb64d999af10129cb7693eee7c1179",
-            "DelayedWethProxy": "0xa130523fd22e2a9d78f8ab232b01ff552845b4a9",
-            "DisputeGameFactoryProxy": "0x8f68e849eaf8eb943536f9d1d49ea9c9b5868b98",
-            "FaultDisputeGame": null,
-            "Mips": "0x66d6be83984e3f026b4a9e2d8fb082ecdbd43648",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0xe7d0fe72637b3c949cd81c63a4ff1fb23feef3b2"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xb356b146f1629c49c44344464f69bcdafb4bb664",
-            "ProxyAdminOwner": "0x70fdbcb066ed3621647ddf61a1f40aac6058bc89",
-            "Guardian": "0xb356b146f1629c49c44344464f69bcdafb4bb664",
-            "Challenger": "0xb356b146f1629c49c44344464f69bcdafb4bb664",
-            "Proposer": "0x4c465e58946145bb2bfc38833154f5a3b5728cf7",
-            "UnsafeBlockSigner": "0xa5bdf717af725a47fd7378d3d9c833776951efa0",
-            "BatchSubmitter": "0xa31cb9bc414601171d4537580f98f66c03aecd43"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Swan Chain Mainnet",
-          "l2_chain_id": 254,
-          "PublicRPC": "https://mainnet-rpc.swanchain.org",
-          "SequencerRPC": "https://sequencer-mainnet.swanchain.org",
-          "Explorer": "https://swanscan.io",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000000254",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": null,
-            "fjord_time": null,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 5,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 20112576,
-              "hash": "0x90dafe09640e2858bce2675c66da6b0f136215a179d49f5c9274252bd5a1f8a2"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x834c39d79eb75c4c52d745e624750b817b66eb13e483b035c42ec3aa5cfa7429"
-            },
-            "l2_time": 1718640215,
-            "system_config": {
-              "batcherAddress": "0xde794bec196832474f2f218135bfd0f7ca7fb038",
-              "overhead": "0x834",
-              "scalar": "0xf4240",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x55aec4ee11da7d655565ccc2eb3bf21a46c94e6f",
-            "L1CrossDomainMessengerProxy": "0x15567c4ffd9109795dff1d9a5233d10aef0738d2",
-            "L1Erc721BridgeProxy": "0x1ccf7e62889e6a93413deafc4e390bd4047bdc32",
-            "L1StandardBridgeProxy": "0xed7525946a09056c6aae29941b8323017382050e",
-            "L2OutputOracleProxy": "0x1c22740a0b4511e11d76434a424487862b593901",
-            "OptimismMintableErc20FactoryProxy": "0xe9614162c6128abd7790c65d711cfc43ea842153",
-            "OptimismPortalProxy": "0xba50434bc5fcc07406b1bad9ac72a4cdf776db15",
-            "SystemConfigProxy": "0x504d56cf68f791b45e3a2e895b0e1562f3431328",
-            "ProxyAdmin": "0xcc8c55ec2ea3f3001c049ec934e72b55cf52fbf3",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": "0x2069fc7097b7784fca21aa459e57e95c0046eecd",
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x3fcb6e08a960ef52ec3101a444f71a2fd964b248",
-            "ProxyAdminOwner": "0x6197f64902b9275e6815f9a5b641ed2291a5d39c",
-            "Guardian": "0x3fcb6e08a960ef52ec3101a444f71a2fd964b248",
-            "Challenger": "0x3fcb6e08a960ef52ec3101a444f71a2fd964b248",
-            "Proposer": "0xb2a5571c23d13ce16ef3e993fbe8d225d3f67366",
-            "UnsafeBlockSigner": "0x05a220507e8f4c73a446dbafc5607016a7d5eab0",
-            "BatchSubmitter": "0xde794bec196832474f2f218135bfd0f7ca7fb038"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "arena-z",
-          "l2_chain_id": 7897,
-          "PublicRPC": "https://rpc.arena-z.gg",
-          "SequencerRPC": "https://rpc.arena-z.gg",
-          "Explorer": "https://explorer.arena-z.gg",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 1736445601,
-          "batch_inbox_address": "0x00f9bcee08dce4f0e7906c1f6cfb10c77802eed0",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 0,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x14",
-            "eip1559Denominator": "0x7d0",
-            "eip1559DenominatorCanyon": "0x7d0"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 21167590,
-              "hash": "0x5e7db5c04973dd6e06ac7e2abf5b9373089f0f09e8ae8231642f0c6aff177e27"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xbe7112a730b1fae8d94115271adc600559ebe87c75df1d2df9414bd7298eb7fb"
-            },
-            "l2_time": 1731366083,
-            "system_config": {
-              "batcherAddress": "0x2b8733e8c60a928b19bb7db1d79b918e8e09ac8c",
-              "overhead": "0x0",
-              "scalar": "0x10000000000000000000000000000000000000000000000000c3a30000060a4",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x1cb5fb7da1444e2d895420442d246787b7afa95d",
-            "L1CrossDomainMessengerProxy": "0x0be364912219bc74760f1d1c25f4866b328ebfc6",
-            "L1Erc721BridgeProxy": "0xbc404ae11e4e9da3ea9276aa6dcca31097d4f4ee",
-            "L1StandardBridgeProxy": "0x564eb0cefcca86160649a8986c419693c82f3678",
-            "L2OutputOracleProxy": null,
-            "OptimismMintableErc20FactoryProxy": "0xa33f75a3a2babd502cbc1a6f54345b529c1f306e",
-            "OptimismPortalProxy": "0xb20f99b598e8d888d1887715439851bc68806b22",
-            "SystemConfigProxy": "0x34a564bbd863c4bf73eca711cf38a77c4ccbdd6a",
-            "ProxyAdmin": "0xeefd1782d70824cbcacf9438afab7f353f1797f0",
-            "AnchorStateRegistryProxy": "0x924911e2ccadb4638447ccd00b6cfb040cc08560",
-            "DelayedWethProxy": "0xaf1308930b721e763a6b21cf143e4e86e702f164",
-            "DisputeGameFactoryProxy": "0x658656a14afdf9c507096ac406564497d13ec754",
-            "FaultDisputeGame": null,
-            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
-            "PermissionedDisputeGame": "0x227882e5972ebad990dcf04e2dbe2fc84094e146",
-            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
-            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
-            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
-            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
-            "Proposer": "0x5f16e66d8736b689a430564a31c8d887ca357cd8",
-            "UnsafeBlockSigner": "0xb774ca8438319d2a97b9925f4cd248e4c470ac5b",
-            "BatchSubmitter": "0x2b8733e8c60a928b19bb7db1d79b918e8e09ac8c"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Zora",
-          "l2_chain_id": 7777777,
-          "PublicRPC": "https://rpc.zora.energy",
-          "SequencerRPC": "https://rpc.zora.energy",
-          "Explorer": "https://explorer.zora.energy",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0x6f54ca6f6ede96662024ffd61bfd18f3f4e34dff",
-          "hardfork_configuration": {
-            "canyon_time": 1704992401,
-            "delta_time": 1708560000,
-            "ecotone_time": 1710374401,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 17473923,
-              "hash": "0xbdbd2847f7aa5f7cd1bd4c9f904057f4ba0b498c7e380199c01d240e3a41a84f"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x47555a45a1af8d4728ca337a1e48375a83919b1ea16591e070a07388b7364e29"
-            },
-            "l2_time": 1686693839,
-            "system_config": {
-              "batcherAddress": "0x625726c858dbf78c0125436c943bf4b4be9d9033",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xef8115f2733fb2033a7c756402fc1deaa56550ef",
-            "L1CrossDomainMessengerProxy": "0xdc40a14d9abd6f410226f1e6de71ae03441ca506",
-            "L1Erc721BridgeProxy": "0x83a4521a3573ca87f3a971b169c5a0e1d34481c3",
-            "L1StandardBridgeProxy": "0x3e2ea9b92b7e48a52296fd261dc26fd995284631",
-            "L2OutputOracleProxy": "0x9e6204f750cd866b299594e2ac9ea824e2e5f95c",
-            "OptimismMintableErc20FactoryProxy": "0xc52bc7344e24e39df1bf026fe05c4e6e23cfbcff",
-            "OptimismPortalProxy": "0x1a0ad011913a150f69f6a19df447a0cfd9551054",
-            "SystemConfigProxy": "0xa3cab0126d5f504b071b81a3e8a2bbbf17930d86",
-            "ProxyAdmin": "0xd4ef175b9e72caee9f1fe7660a6ec19009903b49",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xc72ae5c7cc9a332699305e29f68be66c73b60542",
-            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
-            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
-            "Challenger": "0xca4571b1ecbec86ea2e660d242c1c29fcb55dc72",
-            "Proposer": "0x48247032092e7b0ecf5def611ad89eaf3fc888dd",
-            "UnsafeBlockSigner": "0x3dc8dfd0709c835cad15a6a27e089ff4cf4c9228",
-            "BatchSubmitter": "0x625726c858dbf78c0125436c943bf4b4be9d9033"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Ink",
-          "l2_chain_id": 57073,
-          "PublicRPC": "https://rpc-gel.inkonchain.com",
-          "SequencerRPC": "https://rpc-gel.inkonchain.com",
-          "Explorer": "https://explorer.inkonchain.com",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 1740582000,
-          "batch_inbox_address": "0x005969bf0ecbf6edb6c47e5e94693b1c3651be97",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 0,
-            "holocene_time": 1740582000,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 1,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0xfa",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 21344310,
-              "hash": "0x39e4e0c0c94f8076134b441a9dc18d10b595fd9777edeb763bb9f9bd8f922fd9"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x23a2658170ba70d014ba0d0d2709f8fbfe2fa660cd868c5f282f991eecbe38ee"
-            },
-            "l2_time": 1733498411,
-            "system_config": {
-              "batcherAddress": "0x500d7ea63cf2e501dadaa5feec1fc19fe2aa72ac",
-              "overhead": "0x0",
-              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x9b7c9bbd6d540a8a4dedd935819fc4408ba71153",
-            "L1CrossDomainMessengerProxy": "0x69d3cf86b2bf1a9e99875b7e2d9b6a84426c171f",
-            "L1Erc721BridgeProxy": "0x661235a238b11191211fa95d4dd9e423d521e0be",
-            "L1StandardBridgeProxy": "0x88ff1e5b602916615391f55854588efcbb7663f0",
-            "L2OutputOracleProxy": null,
-            "OptimismMintableErc20FactoryProxy": "0xa8b389a82e088b164cd03230e900980cced34d29",
-            "OptimismPortalProxy": "0x5d66c1782664115999c47c9fa5cd031f495d3e4f",
-            "SystemConfigProxy": "0x62c0a111929fa32cec2f76adba54c16afb6e8364",
-            "ProxyAdmin": "0xd56045e68956fce2576e680c95a4750cf8241f79",
-            "AnchorStateRegistryProxy": "0xde744491bcf6b2dd2f32146364ea1487d75e2509",
-            "DelayedWethProxy": "0x3beaca17eae5643fb1479aa5f4b1ff75cc4b9b50",
-            "DisputeGameFactoryProxy": "0x10d7b35078d3baabb96dd45a9143b94be65b12cd",
-            "FaultDisputeGame": "0x6a8efcba5642eb15d743cbb29545bdc44d5ad8cd",
-            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
-            "PermissionedDisputeGame": "0x0a780be3eb21117b1bbcd74cf5d7624a3a482963",
-            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
-            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
-            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
-            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
-            "Proposer": "0x65436ddcbc026f34118954f229f7f132b696b3b4",
-            "UnsafeBlockSigner": "0x7d056b99aa2021864c42e25b4f8ce3bdeac9463c",
-            "BatchSubmitter": "0x500d7ea63cf2e501dadaa5feec1fc19fe2aa72ac"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Swellchain",
-          "l2_chain_id": 1923,
-          "PublicRPC": "https://swell-mainnet.alt.technology",
-          "SequencerRPC": "https://swell-mainnet.alt.technology",
-          "Explorer": "https://explorer.swellnetwork.io",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0x005de5857e38dfd703a1725c0900e9c6f24cbde0",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 0,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 21277945,
-              "hash": "0xd904f8475cc7b74a9ef4749d0ee9aeca3b233aa3dc143667e8a20ffe43789a26"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x92379973a1576876b7337a9ce89e2a7a9cb99887f55e6045ed2069d5d98d9319"
-            },
-            "l2_time": 1732696703,
-            "system_config": {
-              "batcherAddress": "0xf854cd5b26bfd73d51236c0122798907ed65b1f2",
-              "overhead": "0x0",
-              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
-              "gasLimit": 60000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xa54a84f17c2180148c762d79bc57bdff7fdafc8a",
-            "L1CrossDomainMessengerProxy": "0xe6a99ef12995defc5ff47ec0e13252f0e6903759",
-            "L1Erc721BridgeProxy": "0xfd7618330e63b493070dc8c491ad4ad26144bc1e",
-            "L1StandardBridgeProxy": "0x7aa4960908b13d104bf056b23e2c76b43c5aacc8",
-            "L2OutputOracleProxy": null,
-            "OptimismMintableErc20FactoryProxy": "0xc2b228cd433ebae788de287ede2abe55b3f3f603",
-            "OptimismPortalProxy": "0x758e0ee66102816f5c3ec9ecc1188860fbb87812",
-            "SystemConfigProxy": "0xd3d4c6b703978a5d24fecf3a70a51127667ff1a4",
-            "ProxyAdmin": "0x4c4710a4ec3f514a492cc6460818c4a6a6269dd6",
-            "AnchorStateRegistryProxy": "0x14387438ee964e826a4eaeb95b2bce7754174dd1",
-            "DelayedWethProxy": "0x89c98736a806176fe85283c1cb727ffbdeaf37a9",
-            "DisputeGameFactoryProxy": "0x87690676786cdc8cca75a472e483af7c8f2f0f57",
-            "FaultDisputeGame": null,
-            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
-            "PermissionedDisputeGame": "0xa0cfbe3402d6e0a74e96d3c360f74d5ea4fa6893",
-            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x06f7fb1c74147e34fce04a6828c7bf809b038d0e",
-            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
-            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
-            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
-            "Proposer": "0xfe5dd32c3799249dc6a5d637ccb2f28e0ec227e3",
-            "UnsafeBlockSigner": "0x6967d304e9b7e26b5eb3f5a1fd1239daad3215e6",
-            "BatchSubmitter": "0xf854cd5b26bfd73d51236c0122798907ed65b1f2"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Ethernity",
-          "l2_chain_id": 183,
-          "PublicRPC": "https://mainnet.ethernitychain.io",
-          "SequencerRPC": "https://mainnet.ethernitychain.io",
-          "Explorer": "https://ernscan.io",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xff00000000000000000000000000000000000183",
-          "hardfork_configuration": {
-            "canyon_time": 1704992401,
-            "delta_time": 1708560000,
-            "ecotone_time": 1710374401,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x14",
-            "eip1559Denominator": "0x3e8",
-            "eip1559DenominatorCanyon": "0x3e8"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 20519340,
-              "hash": "0xbb7ad201b0ab296465865642878e9256e0fa4a3f8d06bca1f3e5c5b54be6be90"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xa5e974a6ace39285b42f92316a9e040e58f8ffc24e3aac124ff6243c28323607"
-            },
-            "l2_time": 1723547735,
-            "system_config": {
-              "batcherAddress": "0x43ca061ea80fbb4a2b5515f4be4e953b191147af",
-              "overhead": "0xbc",
-              "scalar": "0xf4240",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x464ca56d40f94e8a50efa7f5b90c59d956a0efc9",
-            "L1CrossDomainMessengerProxy": "0x226a1e4a3d8e64a9de8423f9344348c179c72cb2",
-            "L1Erc721BridgeProxy": "0x00050ae93fbfaf5823a4ae229e4651f7f7a02ffa",
-            "L1StandardBridgeProxy": "0x908c324c35ff36f64236a7cda4d50f3003e9c5c3",
-            "L2OutputOracleProxy": "0x0eb331b615030819464225ecd373e5ffbe502dc4",
-            "OptimismMintableErc20FactoryProxy": "0x45beaf3bd26b76796692b1ef1e67469b84adb914",
-            "OptimismPortalProxy": "0xda29f0b4da6c23f6c1af273945c290c0268c4ea9",
-            "SystemConfigProxy": "0x20c3035c92bdb4c461242571eeac59eed03df931",
-            "ProxyAdmin": "0x0bc380347a0b7af5453492caf20e1e38bc0abc2f",
-            "AnchorStateRegistryProxy": "0x31ee18f4dbca6a9c8599508ec70ab98cb1118e9e",
-            "DelayedWethProxy": "0xde1999df1f225d638ad3ca2c9eb5b2e52730d950",
-            "DisputeGameFactoryProxy": "0xfcdb270b674911d321f1014c347eabb1c55134fb",
-            "FaultDisputeGame": null,
-            "Mips": "0x94ce3d0b2243250d3f33df45faaeac273ca945fe",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0xa0455f010561671c640d80f51851d51318ac32ab"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
-            "ProxyAdminOwner": "0xb68361aaac2bc8a4b8bfe36b8c6d0b429b5930ea",
-            "Guardian": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
-            "Challenger": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
-            "Proposer": "0xf49212f977986347b73345d382a811e148751eed",
-            "UnsafeBlockSigner": "0xd1705b4fffc540eded73046ee1f3a8db10d143f8",
-            "BatchSubmitter": "0x43ca061ea80fbb4a2b5515f4be4e953b191147af"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Lisk",
-          "l2_chain_id": 1135,
-          "PublicRPC": "https://rpc.api.lisk.com",
-          "SequencerRPC": "https://rpc.api.lisk.com",
-          "Explorer": "https://blockscout.lisk.com",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xff00000000000000000000000000000000001135",
-          "hardfork_configuration": {
-            "canyon_time": 1704992401,
-            "delta_time": 1708560000,
-            "ecotone_time": 1710374401,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x14",
-            "eip1559Denominator": "0x3e8",
-            "eip1559DenominatorCanyon": "0x3e8"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 19788720,
-              "hash": "0xd580bdbd001908860f225c16ddaa08ada64471a68435694760c111253d97ffce"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x5a693d1d8ee27b8e62868d0349af430a2d2e173c8c8988e7b0c9ef91893cbf00"
-            },
-            "l2_time": 1714728791,
-            "system_config": {
-              "batcherAddress": "0xa6ea2f3299b63c53143c993d2d5e60a69cd6fe24",
-              "overhead": "0xbc",
-              "scalar": "0xf4240",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x2df7057d3f25212e51afea8da628668229ea423f",
-            "L1CrossDomainMessengerProxy": "0x31b72d76fb666844c41edf08df0254875dbb7edb",
-            "L1Erc721BridgeProxy": "0x3a44a3b263fb631cdbf25f339e2d29497511a81f",
-            "L1StandardBridgeProxy": "0x2658723bf70c7667de6b25f99fcce13a16d25d08",
-            "L2OutputOracleProxy": "0x113cb99283af242da0a0c54347667edf531aa7d6",
-            "OptimismMintableErc20FactoryProxy": "0xc1da06cc5dd5ce23baba924463de7f762039252d",
-            "OptimismPortalProxy": "0x26db93f8b8b4f7016240af62f7730979d353f9a7",
-            "SystemConfigProxy": "0x05f23282ffdca8286e4738c1af79079f3d843750",
-            "ProxyAdmin": "0xec432c4f1d0e12737f3a42a459b84848af979b2d",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": "0x0479e6757eb4743843b309dddf78e6ba242f38be",
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
-            "ProxyAdminOwner": "0xecd4150abbb1ebff13f74e42fb43c3d78b4e0b45",
-            "Guardian": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
-            "Challenger": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
-            "Proposer": "0x0abd6da1ce10d1cd6c7c9c14b905786d20f3eb23",
-            "UnsafeBlockSigner": "0xb9de90a90c5e441c483e754fe7341100d5fbaeca",
-            "BatchSubmitter": "0xa6ea2f3299b63c53143c993d2d5e60a69cd6fe24"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Xterio Chain (ETH)",
-          "l2_chain_id": 2702128,
-          "PublicRPC": "https://xterio-eth.alt.technology/",
-          "SequencerRPC": "https://xterio-eth.alt.technology/",
-          "Explorer": "https://eth.xterscan.io/",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000293b30",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": null,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "alt-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": {
-            "da_challenge_address": null,
-            "da_challenge_window": 3600,
-            "da_resolve_window": 3600
-          },
-          "genesis": {
-            "l1": {
-              "number": 19938395,
-              "hash": "0x813c7b630e1d98a36dc26653406746f020b4f699381c2dbccaf51ef6dfd29ac2"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xb99fa3b9c265fe5364ed7ee2aca78535aaffd04e7b21f40383ed19a1c6d1d63b"
-            },
-            "l2_time": 1716537431,
-            "system_config": {
-              "batcherAddress": "0x7d6251d49a102a330cfb46d132982781620700cb",
-              "overhead": "0xb4",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xbdf852e2cc26ea3c2dee7b493b1fc12da406175a",
-            "L1CrossDomainMessengerProxy": "0x702df90e92a6841c9013fae6d724ddfa8f141d5c",
-            "L1Erc721BridgeProxy": "0x28d56c3bbbe4807c19cc81e6d5207fb681c3726b",
-            "L1StandardBridgeProxy": "0x2ad84abd52050956acc9c490d024b821a59e3fb6",
-            "L2OutputOracleProxy": "0x5a0492d20d984ee904e46e6ff24572bc755abb28",
-            "OptimismMintableErc20FactoryProxy": "0x515a0c8b1d9574c65ea1924ecd767b1d9b6ac32f",
-            "OptimismPortalProxy": "0xbc2beda4ce7a1f40aa458322a33b44081b2f545a",
-            "SystemConfigProxy": "0x6e99cde188daafeecb6ed8ac28b98de4c8ee5d6c",
-            "ProxyAdmin": "0x9e48d6bbca781c23392ec459bfb3657c40a794a8",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": "0x0ece16401a80551345bb672f177f51a8755ff775",
-            "DisputeGameFactoryProxy": "0x443164f044d8840479234e00e7ad5bb06b85fc78",
-            "FaultDisputeGame": null,
-            "Mips": "0x253ddbb3549e0cefaaaa7f71be502c5b94771ddc",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x089a4754538b74ff63bc6abead7a95973ab03572"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xcf06c459ae59d4f47469bce535afc3485ce89dbf",
-            "ProxyAdminOwner": "0xff75bd7672b79f2562faf98d488bbb3db1cd1574",
-            "Guardian": "0xdf3700a9cf9c7506ca3b41e6ba991476677a8787",
-            "Challenger": "0xfa8d42bde52c2b8b05fe5eecbadea6cb698a0bc5",
-            "Proposer": "0x7d2f9b38866141bf090dd670a826f27ea2408ad4",
-            "UnsafeBlockSigner": "0xcbdd38ce74ba96f0ae3d2e608da96ec744c80a7e",
-            "BatchSubmitter": "0x7d6251d49a102a330cfb46d132982781620700cb"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Orderly Mainnet",
-          "l2_chain_id": 291,
-          "PublicRPC": "https://rpc.orderly.network",
-          "SequencerRPC": "https://rpc.orderly.network",
-          "Explorer": "https://explorer.orderly.network",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0x08aa34cc843ceebcc88a627f18430294aa9780be",
-          "hardfork_configuration": {
-            "canyon_time": 1704992401,
-            "delta_time": 1708560000,
-            "ecotone_time": 1710374401,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "alt-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 18292529,
-              "hash": "0x787d5dd296d63bc6e7a4158d4f109e1260740ee115f5ed5124b35dece1fa3968"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xe53c94ddd42714239429bd132ba2fa080c7e5cc7dca816ec6e482ec0418e6d7f"
-            },
-            "l2_time": 1696608227,
-            "system_config": {
-              "batcherAddress": "0xf8db8aba597ff36ccd16fecfbb1b816b3236e9b8",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x87630a802a3789463ec4b00f89b27b1e9f6b92e9",
-            "L1CrossDomainMessengerProxy": "0xc76543a64666d9a073faef4e75f651c88e7dbc08",
-            "L1Erc721BridgeProxy": "0x934ab59ef14b638653b1c0fef7ab9a72186393dc",
-            "L1StandardBridgeProxy": "0xe07ea0436100918f157df35d01dce5c11b16d1f1",
-            "L2OutputOracleProxy": "0x5e76821c3c1abb9fd6e310224804556c61d860e0",
-            "OptimismMintableErc20FactoryProxy": "0x7a69a90d8ea11e9618855da55d09e6f953730686",
-            "OptimismPortalProxy": "0x91493a61ab83b62943e6dcaa5475dd330704cc84",
-            "SystemConfigProxy": "0x886b187c3d293b1449a3a0f23ca9e2269e0f2664",
-            "ProxyAdmin": "0xb570f4ad27e7de879a2e4f2f3de27dbabc20e9b9",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Guardian": "0xce10372313ca39fbf75a09e7f4c0e57f070259f4",
-            "Challenger": "0xce10372313ca39fbf75a09e7f4c0e57f070259f4",
-            "Proposer": "0x74bad482a7f73c8286f50d8aa03e53b7d24a5f3b",
-            "UnsafeBlockSigner": "0xceed24b1fd4a4393f6a9d2b137d9597dd5482569",
-            "BatchSubmitter": "0xf8db8aba597ff36ccd16fecfbb1b816b3236e9b8"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Shape",
-          "l2_chain_id": 360,
-          "PublicRPC": "https://mainnet.shape.network/",
-          "SequencerRPC": "https://shape-mainnet-sequencer.g.alchemy.com",
-          "Explorer": "https://shape-mainnet.explorer.alchemy.com/",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000000360",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 1727370000,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 1800,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 20369793,
-              "hash": "0x64772c7ca14e37ca9f0662b7d16b250f486218656012c0da994396608584b2b1"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xf17c665ffdebe214ec214bcd798c725141e7b5c29799500abd6a8738d15bdebe"
-            },
-            "l2_time": 1721744471,
-            "system_config": {
-              "batcherAddress": "0xf7ca543d652e38692fd12f989eb55b5327ec9a20",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xcee78437ae9e15cee9c78e63757e0153c0fd7479",
-            "L1CrossDomainMessengerProxy": "0x2b18602877181c3cb72c687e2a771e123a3788e3",
-            "L1Erc721BridgeProxy": "0xe9d3e49b0636016c5fe9eaa2347948d0ba9f15af",
-            "L1StandardBridgeProxy": "0x62edd5f4930ea92dca3fb81689bdd9b9d076b57b",
-            "L2OutputOracleProxy": "0x6ef8c69cfe4635d866e3e02732068022c06e724d",
-            "OptimismMintableErc20FactoryProxy": "0x319322906beadf69df5d4607169c63d692b1adc1",
-            "OptimismPortalProxy": "0xeb06ffa16011b5628bab98e29776361c83741dd3",
-            "SystemConfigProxy": "0xff11e41d5c4f522e423ff6c064ff8d55af8f7355",
-            "ProxyAdmin": "0x11b190ae661c6d6884dfee48e215691e0ddb842e",
-            "AnchorStateRegistryProxy": "0x02987e7294379b9dda99d593b0c94c68266222d1",
-            "DelayedWethProxy": "0xfec7865dac5139886585f03146ff61d9b31c2d57",
-            "DisputeGameFactoryProxy": "0x575aecd84083f93877291901907698f7db0bd8b0",
-            "FaultDisputeGame": null,
-            "Mips": "0xd30c2cd3cd6112e61fdfb03e4b232564d7e5c91f",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0xdf6a16a71d0bc7a1bbe8fffb33700ec3d9448a5b"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xee1af3f99af8c5b93512fbe2a3f0dd5568ce087f",
-            "ProxyAdminOwner": "0xacaf178b5048cb56712dc59e95fba72f7990a005",
-            "Guardian": "0xee1af3f99af8c5b93512fbe2a3f0dd5568ce087f",
-            "Challenger": "0xee1af3f99af8c5b93512fbe2a3f0dd5568ce087f",
-            "Proposer": "0x0d8a607f3d2de86add04df00f06794cb339a40de",
-            "UnsafeBlockSigner": "0x9c66333c504f3a4f5593d0e9739434744ccc5b5d",
-            "BatchSubmitter": "0xf7ca543d652e38692fd12f989eb55b5327ec9a20"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Metal L2",
-          "l2_chain_id": 1750,
-          "PublicRPC": "https://rpc.metall2.com",
-          "SequencerRPC": "https://rpc.metall2.com",
-          "Explorer": "https://explorer.metall2.com",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xc83f7d9f2d4a76e81145849381aba02602373723",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 19527340,
-              "hash": "0x2493565ce8472656b7c22377c8d4d8ef5d17f78392c799ca5f2429b01e2c159c"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xd31c12ffff2d563897ad9a041c0d26790d635911bdbbfa589347fa955f75281e"
-            },
-            "l2_time": 1711563515,
-            "system_config": {
-              "batcherAddress": "0xc94c243f8fb37223f3eb2f7961f7072602a51b8b",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xd4b1ec0dec3c7f12abd3ec27b7514880ae1c3a37",
-            "L1CrossDomainMessengerProxy": "0x0a47a44f1b2bb753474f8c830322554a96c9934d",
-            "L1Erc721BridgeProxy": "0x50d700e97967f9115e3f999bdb263d69f6704680",
-            "L1StandardBridgeProxy": "0x6d0f65d59b55b0fec5d2d15365154dcadc140bf3",
-            "L2OutputOracleProxy": "0x3b1f7ada0fcc26b13515af752dd07fb1cac11426",
-            "OptimismMintableErc20FactoryProxy": "0x1aaab4e20d2e4bb992b5bca2125e8bd3588c8730",
-            "OptimismPortalProxy": "0x3f37abde2c6b5b2ed6f8045787df1ed1e3753956",
-            "SystemConfigProxy": "0x7bd909970b0eedcf078de6aeff23ce571663b8aa",
-            "ProxyAdmin": "0x37ff0ae34dada1a95a4251d10ef7caa868c7ac99",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
-            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
-            "Challenger": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Proposer": "0xc8187d40ad440328104a52bbed2d8efc5ab1f1f6",
-            "UnsafeBlockSigner": "0x4a65f5da5e80deffea844eaa15ce130e80605dc5",
-            "BatchSubmitter": "0xc94c243f8fb37223f3eb2f7961f7072602a51b8b"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Soneium",
-          "l2_chain_id": 1868,
-          "PublicRPC": "https://rpc.soneium.org",
-          "SequencerRPC": "https://rpc.soneium.org",
-          "Explorer": "https://soneium.blockscout.com/",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 1738573200,
-          "batch_inbox_address": "0x008dc74cecc9deda8595b2fe210ce5979f0bfa8e",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 0,
-            "holocene_time": 1738573200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 21314185,
-              "hash": "0x68b4ad05c3dafc2613853d26cf39f0e1716e986f879207440f187b56c12cb4d6"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x295d22d269634c7d0055b33b887519362d0b31899e97109d1789a8a168de1b21"
-            },
-            "l2_time": 1733134751,
-            "system_config": {
-              "batcherAddress": "0x6776be80dbada6a02b5f2095cf13734ac303b8d1",
-              "overhead": "0x0",
-              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
-              "gasLimit": 60000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xb24bfeece1b3b7a44559f4cbc21bed312b130b70",
-            "L1CrossDomainMessengerProxy": "0x9cf951e3f74b644e621b36ca9cea147a78d4c39f",
-            "L1Erc721BridgeProxy": "0x5933e323be8896dfacd1cd671442f27daa10a053",
-            "L1StandardBridgeProxy": "0xeb9bf100225c214efc3e7c651ebbadcf85177607",
-            "L2OutputOracleProxy": null,
-            "OptimismMintableErc20FactoryProxy": "0xc1047e30efc9e172cfe7aa0219895b6a43fc415f",
-            "OptimismPortalProxy": "0x88e529a6ccd302c948689cd5156c83d4614fae92",
-            "SystemConfigProxy": "0x7a8ed66b319911a0f3e7288bddab30d9c0c875c3",
-            "ProxyAdmin": "0x89889b569c3a505f3640ee1bd0ac1d557f436d2a",
-            "AnchorStateRegistryProxy": "0x61f89a381e0be13bd8ab356cf4b7301bc97d7522",
-            "DelayedWethProxy": "0x9cf951e3f74b644e621b36ca9cea147a78d4c39f",
-            "DisputeGameFactoryProxy": "0x512a3d2c7a43bd9261d2b8e8c9c70d4bd4d503c0",
-            "FaultDisputeGame": null,
-            "Mips": "0x16e83ce5ce29bf90ad9da06d2fe6a15d5f344ce4",
-            "PermissionedDisputeGame": "0x42d15f045159ce4ade9edc7da5704ef36056c936",
-            "PreimageOracle": "0x9c065e11870b891d214bc2da7ef1f9ddfa1be277"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x509182ec226b3b71d36a3255a80ef0b1a9d43033",
-            "ProxyAdminOwner": "0x5a0aae59d09fccbddb6c6cceb07b7279367c3d2a",
-            "Guardian": "0x09f7150d8c019bef34450d6920f6b3608cefdaf2",
-            "Challenger": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
-            "Proposer": "0x400c164c4a8ca84385b70eed6eb03ea847c8e1b8",
-            "UnsafeBlockSigner": "0x7c2bd59ee2a2c7391c9a240132f26071e9546262",
-            "BatchSubmitter": "0x6776be80dbada6a02b5f2095cf13734ac303b8d1"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Superseed",
-          "l2_chain_id": 5330,
-          "PublicRPC": "https://mainnet.superseed.xyz",
-          "SequencerRPC": "https://mainnet.superseed.xyz",
-          "Explorer": "https://explorer.superseed.xyz",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0x8612014a343089f1ddbacfd42baf4afbf9133593",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 20737477,
-              "hash": "0x32566bf75b83734e532a687ad0c1d0b884e544815498401696ca5a49df238cf2"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x0e5eb156fd2ea921d57ee4921191a2a46ebe3a11854ee7a63a5c6c580aa99219"
-            },
-            "l2_time": 1726179683,
-            "system_config": {
-              "batcherAddress": "0xa9b074b27de97f492f8f07fd7c213400e4ca5391",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x0a1b34aa2047ad1abef8ac085b1a7802ed9dbcf0",
-            "L1CrossDomainMessengerProxy": "0x3a30aed8fa7717ac2d8454d82c125cf6b875061a",
-            "L1Erc721BridgeProxy": "0xa99f82730e68968a78aa21522fc7eb90db76d8cb",
-            "L1StandardBridgeProxy": "0x8b0576e39f1233679109f9b40cfcc2a7e0901ede",
-            "L2OutputOracleProxy": "0x693a0f8854f458d282de3c5b69e8ee5eee8aa949",
-            "OptimismMintableErc20FactoryProxy": "0x484529223d68a0cf85902bf5e781394f0d0f837c",
-            "OptimismPortalProxy": "0x2c2150aa5c75a24fb93d4fd2f2a895d618054f07",
-            "SystemConfigProxy": "0x525a2744134805516a45b8abb6aa0aa1da3809f6",
-            "ProxyAdmin": "0xf3b7697c9c0cbde923f34991f2d19cc1c66612bd",
-            "AnchorStateRegistryProxy": "0xac1e4b08300c6c4705918089ee10b286b3ec24df",
-            "DelayedWethProxy": "0xec4dc88475a2887e73b2073b60425575fd693c0a",
-            "DisputeGameFactoryProxy": "0x8b097cf1f9bbd9cbfd0dd561858a1fcbc8857be0",
-            "FaultDisputeGame": null,
-            "Mips": "0x7f4f96cd3719f2829117c8c5e810e01dbd6846ba",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0xb18202e3e4dbf7abcea623a38526aad5a64dcd59"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Guardian": "0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a",
-            "Challenger": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Proposer": "0xb2354bdf5925d03ca06b03a7bd7386bd685ce814",
-            "UnsafeBlockSigner": "0x92dc533201e8634f0337d66a11820a8c4e902474",
-            "BatchSubmitter": "0xa9b074b27de97f492f8f07fd7c213400e4ca5391"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Polynomial",
-          "l2_chain_id": 8008,
-          "PublicRPC": "https://rpc.polynomial.fi",
-          "SequencerRPC": "https://rpc.polynomial.fi",
-          "Explorer": "https://polynomialscan.io",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0x0bd57e83b5e0f9ecd84d559bb58e1ecfeedd2565",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1720627201,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 20062729,
-              "hash": "0xc6d18992ff6e4c9e4798d34a7b97423a7ec276e9f2bbecfd4bb69ccdd49f516a"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x1b5e76ad2f290fb6fa2c60755d8c52942dbefedab76d01091e24080d5c129fd0"
-            },
-            "l2_time": 1718038175,
-            "system_config": {
-              "batcherAddress": "0x67a44ce38627f46f20b1293960559ed85dd194f1",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x287bba8116f2fc5a642bfd6027ebf5ad6522655c",
-            "L1CrossDomainMessengerProxy": "0x36725a5e0040deb7c697d46c0e24390702b202e0",
-            "L1Erc721BridgeProxy": "0xd5890bbafafdce942597757385e55174569e8d1a",
-            "L1StandardBridgeProxy": "0x3be64bf2b9c2de637067c7aab6bae5edf9feba55",
-            "L2OutputOracleProxy": "0xe512d477cc89196af2ce837f6ab8ea30e199f757",
-            "OptimismMintableErc20FactoryProxy": "0x994233366c8e11da5c525ab903c04e7afb2915bd",
-            "OptimismPortalProxy": "0x034cbb620d1e0e4c2e29845229beac57083b04ec",
-            "SystemConfigProxy": "0x58b51fb9feed00dd846f91d265eba3cdd855a413",
-            "ProxyAdmin": "0x3c68b1d45f4faa4f028c3dc8910fa3247c7f0a1f",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "ProxyAdminOwner": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Guardian": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Challenger": "0x4a4962275df8c60a80d3a25faec5aa7de116a746",
-            "Proposer": "0x5da28f0186051a9f7b9ee2553ffdc165eb0a6714",
-            "UnsafeBlockSigner": "0x11e2785dcc88fbd03ea71df324cbbb0a529b88a2",
-            "BatchSubmitter": "0x67a44ce38627f46f20b1293960559ed85dd194f1"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Binary Mainnet",
-          "l2_chain_id": 624,
-          "PublicRPC": "https://rpc.zero.thebinaryholdings.com",
-          "SequencerRPC": "https://sequencer.bnry.mainnet.zeeve.net",
-          "Explorer": "https://explorer.thebinaryholdings.com",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 1726070401,
-          "batch_inbox_address": "0xff00000000000000000000000000000000000624",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1725536344,
-            "granite_time": 1726070401,
-            "holocene_time": 1736445601,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 20175246,
-              "hash": "0xdcc5838ee3dd0af995c87bec9614a09f08dd8979014876b42fd7e3ae044dd8c4"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xe222b4b07ee9c885d13ee341823c92aa449f9769ac68fb5f1e1d4e602a990a4a"
-            },
-            "l2_time": 1719397463,
-            "system_config": {
-              "batcherAddress": "0x7f9d9c1bce1062e1077845ea39a0303429600a06",
-              "overhead": "0x0",
-              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x8173904703995c6bba59a42b8bbf8405f978758a",
-            "L1CrossDomainMessengerProxy": "0x807d21e416434ae92c8e5bca4d506781afbba380",
-            "L1Erc721BridgeProxy": "0x1b396e4dc6ecb0be33cf01c5a34e1a3a7d03c378",
-            "L1StandardBridgeProxy": "0xd1b30378cbf968e5525e8835219a5726a1e71d10",
-            "L2OutputOracleProxy": "0x012f4baa6e0f5ac4dfdf47bddd9cf68a2b17821e",
-            "OptimismMintableErc20FactoryProxy": "0xa641e14b685b5e652865e14a4fbc07e51371d124",
-            "OptimismPortalProxy": "0x5ff88fcf8e9947f45f4caf8ffd5231b5ddf05e0a",
-            "SystemConfigProxy": "0x7ac7e5989eac278b7bbfef560871a2026bad472c",
-            "ProxyAdmin": "0x38593cce8fab9887ef9760f5f6ab3d6c595143cf",
-            "AnchorStateRegistryProxy": "0x275abd1eb1fbaab40dcef5f3a588e2df65801edc",
-            "DelayedWethProxy": "0x161914f701d090824c1a8a0f4e5666938f12848d",
-            "DisputeGameFactoryProxy": "0x0d7e0590c58e4ac9b14b3ed6163cf55223931699",
-            "FaultDisputeGame": null,
-            "Mips": "0x4e66d89ddf5a9d86836abb1d05ff8fdb5ad32c9a",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0xb9ff3a5835144b0d2f4267a21e0c74458907c870"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x25a6e7c6f3d0fe89a656fcf065614b74e55099ff",
-            "ProxyAdminOwner": "0x48ec051349ddc7e8babafcbfe27696ecf2a8a8b3",
-            "Guardian": "0x87aab081ac9f8ce80fb048f23280df019036ba1d",
-            "Challenger": "0x79ddf0745d14783cdc2a05624c585ddce07f4a02",
-            "Proposer": "0x2b6cd940abe0caf2fd89155b99522548c00ebab1",
-            "UnsafeBlockSigner": "0xdbad225d1c0dabc27f6a9d250dbb136413c0dfb4",
-            "BatchSubmitter": "0x7f9d9c1bce1062e1077845ea39a0303429600a06"
-          },
-          "GasPayingToken": "0x04e9d7e336f79cdab911b06133d3ca2cd0721ce3"
-        },
-        {
-          "Name": "Automata Mainnet",
-          "l2_chain_id": 65536,
-          "PublicRPC": "https://rpc.ata.network",
-          "SequencerRPC": "https://automata-mainnet.alt.technology/",
-          "Explorer": "https://explorer.ata.network",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000001111111",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 7200,
-          "max_sequencer_drift": 1800,
-          "DataAvailabilityType": "alt-da",
-          "optimism": {
-            "eip1559Elasticity": "0xa",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": {
-            "da_challenge_address": null,
-            "da_challenge_window": 3600,
-            "da_resolve_window": 3600
-          },
-          "genesis": {
-            "l1": {
-              "number": 20323239,
-              "hash": "0x2f2ea5358078fdc01d978ff85a3a8fb2efff470b624ba95c5eef0ecd75a6e81d"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x11bb44203634fd85571a9971e6f09d633cbf22826681f809283081ff4e1b5192"
-            },
-            "l2_time": 1721183063,
-            "system_config": {
-              "batcherAddress": "0x5bef09f138921ef7985d83aab97da1db6e4dd190",
-              "overhead": "0x0",
-              "scalar": "0x100000000000000000000000000000000000000000000000000000000013880",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xf1c911e0c1e6dd08c8a7c80c9890e2037e0504c6",
-            "L1CrossDomainMessengerProxy": "0x825c858149f1e775a0f4aeb172037b970be7b736",
-            "L1Erc721BridgeProxy": "0x00bd00c5c7f60e222d9cb8040270ba929241a280",
-            "L1StandardBridgeProxy": "0xe639919b92ab6dd238aeacc6f2a8d6e355d17bd5",
-            "L2OutputOracleProxy": "0xdbf381984c4515fe3285d3c55fdfb3054c52c261",
-            "OptimismMintableErc20FactoryProxy": "0xa74b7baf04867e62b7824268e96144e503a23666",
-            "OptimismPortalProxy": "0xd52ba64cbe1e3b44167f810622fbef36be24d95c",
-            "SystemConfigProxy": "0x72934d7aedc1a2d889ca89aaf064cd9455e64d00",
-            "ProxyAdmin": "0x7617f4a55d62b9ee49578d9c90593e58e607415f",
-            "AnchorStateRegistryProxy": "0x4daa22ec75406e8ea2c70610115850912a770a3a",
-            "DelayedWethProxy": "0xd015f61f3cb26560507d758a726c77d18bf849bb",
-            "DisputeGameFactoryProxy": "0xb52337f38747d6931f2976eea24a3f3f6b7cdea2",
-            "FaultDisputeGame": null,
-            "Mips": "0x2b0293a059a2715935fa9459c9f3a4dce2bc6331",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x4a7bd533be022e7a2911c3c61e7e11e7a32ee77d"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x49ec5bd8c9cc35ce26b87e534d2e36980621ddd2",
-            "ProxyAdminOwner": "0x03ec1c43434e2f910a2fb984906cd2470fdb39c8",
-            "Guardian": "0xa5822fb7e3fb516e518e2629e6786e93858e41f4",
-            "Challenger": "0x34faa77b4d1686e399c96def0de31d30572eaa9f",
-            "Proposer": "0x8c6f6580c846634c5da08c40ae308de23006a679",
-            "UnsafeBlockSigner": "0xa940a669dae672111fd02df597cf7de7cf758fad",
-            "BatchSubmitter": "0x5bef09f138921ef7985d83aab97da1db6e4dd190"
-          },
-          "GasPayingToken": "0xa2120b9e674d3fc3875f415a7df52e382f141225"
-        }
-      ]
-    },
-    {
-      "name": "sepolia",
-      "config": {
-        "name": "Sepolia",
-        "l1": {
-          "chain_id": 11155111,
-          "public_rpc": "https://ethereum-sepolia-rpc.publicnode.com",
-          "explorer": "https://sepolia.etherscan.io"
-        },
-        "protocol_versions_addr": "0x79add5713b383daa0a138d3c4780c7a1804a8090",
-        "superchain_config_addr": "0xc2be75506d5724086deb7245bd260cc9753911be",
-        "OPContractsManagerProxyAddr": null
-      },
-      "chains": [
-        {
-          "Name": "Pivotal Sepolia",
-          "l2_chain_id": 16481,
-          "PublicRPC": "https://sepolia.pivotalprotocol.com/",
-          "SequencerRPC": "https://sepolia.pivotalprotocol.com/",
-          "Explorer": "https://sepolia.pivotalscan.org/",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff000000000000000000000b0000000000016481",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": null,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6548454,
-              "hash": "0x416fb0d9f67e3b0e9701c6bfcb03a13732ddb397158fa8c2ed6e53a33c10995c"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xac7379723e9ff584c00e1cbeb20e76c36dbc98dc8bf2146d1df317b7b6636b91"
-            },
-            "l2_time": 1724315616,
-            "system_config": {
-              "batcherAddress": "0xc122b4d47644bbd7a98e41dd242d20054a11f720",
-              "overhead": "0x0",
-              "scalar": "0xf4240",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x40601f9c44ec842e3faa45cad15d475b450d9277",
-            "L1CrossDomainMessengerProxy": "0x1f6393c113b9c221fbcfb17c163c88d4bda172b0",
-            "L1Erc721BridgeProxy": "0x079ba88edd1be4fefb5011b61714df9ef092ad8f",
-            "L1StandardBridgeProxy": "0x788de2b0dd35808a05eaff7aaf5578b21e0dd9a7",
-            "L2OutputOracleProxy": "0x8a5f3b0897d9b9ba09fd2974f3abe038c15aaba9",
-            "OptimismMintableErc20FactoryProxy": "0x9aee2cf874fe76bf91cd63722db45212be48c5e3",
-            "OptimismPortalProxy": "0x923b28e0037a799a1e60368e60c92dffba982162",
-            "SystemConfigProxy": "0x5c72ce6ea707037bc476da8f4f969bc1f8abc78b",
-            "ProxyAdmin": "0xd79bd9c4a711d053c7f2e62526e3c4442b6b526f",
-            "AnchorStateRegistryProxy": "0x76b5568b3fe823c8d4dbb1d64e055f9e8d847fab",
-            "DelayedWethProxy": "0xe446ecee5bd4102f6366ef3551906adc40f3fc2a",
-            "DisputeGameFactoryProxy": "0xcb97c9224af16c95b8d8959a2752ef1832eb8ba9",
-            "FaultDisputeGame": null,
-            "Mips": "0x183a472b3e8724d4309895c8f1615ad49b6cc469",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0xb3aab329abb207583659e2546e9f24f32ea668e1"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xc121e7f785ac0e5b1da6c7316326412d1c4eb28c",
-            "ProxyAdminOwner": "0x1d60661f40acc64e38fcade8979d22a9b9278e6e",
-            "Guardian": "0xc121e7f785ac0e5b1da6c7316326412d1c4eb28c",
-            "Challenger": "0xc121e7f785ac0e5b1da6c7316326412d1c4eb28c",
-            "Proposer": "0xc12309aac4bd25dbf7df460fddd93f621ee5da3b",
-            "UnsafeBlockSigner": "0xc120bd1178485def5f761f85a4a393200a0aefd6",
-            "BatchSubmitter": "0xc122b4d47644bbd7a98e41dd242d20054a11f720"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Creator Chain Testnet",
-          "l2_chain_id": 66665,
-          "PublicRPC": "https://rpc.creatorchain.io",
-          "SequencerRPC": "https://rpc.creatorchain.io",
-          "Explorer": "https://explorer.creatorchain.io",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xfa5c2402828228a8dd700ba1e71f5e1128876fa8",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 1723478400,
-            "holocene_time": 1732633200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6576576,
-              "hash": "0xe84d982c811eafc34801b0fdab8249739495ada50d119a58128aae583a801529"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x218eeee63576977ed59d751a04ef53ac7ecf6c053331a6f10672c38d211957ed"
-            },
-            "l2_time": 1724698536,
-            "system_config": {
-              "batcherAddress": "0xa488310ab2f8aa3294903930023bcab5880cb1ba",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x35236af82c775965183a7b9cf94fe8bf5665b072",
-            "L1CrossDomainMessengerProxy": "0x19f3d95a281f9cf6aa2c6e8b7ca7c6be83e41f3a",
-            "L1Erc721BridgeProxy": "0xe82526042dae3f8800f87232b5146ed4012ee426",
-            "L1StandardBridgeProxy": "0x78558fd5c8dc65d10753f004bfc4cfa8e199c668",
-            "L2OutputOracleProxy": "0x54e9be93b9a1aca9c0293db7710d9d18273afe1d",
-            "OptimismMintableErc20FactoryProxy": "0xd33347f9c147304c27b9502f1ad93b556bd9df12",
-            "OptimismPortalProxy": "0x1cb215554f36f518791b2e7359a73c96bfcadf69",
-            "SystemConfigProxy": "0x978e8311a5a710ef6413aba3a6b89092ce4a58f5",
-            "ProxyAdmin": "0xb235b455edd534bcac6028f38029cc128b144582",
-            "AnchorStateRegistryProxy": "0x1c2b5dbdba4da7cbe669e73b7f18041e16ecb993",
-            "DelayedWethProxy": "0x77877c3a557457edc27c5f650ce2f4521585a3ec",
-            "DisputeGameFactoryProxy": "0x5eb3040aeebc69595b4bdc4ecb97323330f14517",
-            "FaultDisputeGame": null,
-            "Mips": "0x09fee86ee30d0cf86a8e48089f958c1c04fa5700",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x7328668bbe05eb322b208410652cd41a6bd07a83"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
-            "ProxyAdminOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
-            "Guardian": "0xa9ff930151130fd19da1f03e5077afb7c78f8503",
-            "Challenger": "0x45effbd799ab49122eeeab75b78d9c56a187f9a7",
-            "Proposer": "0x4c67831dba16b1e60cf8f626424082a62f1a2fe5",
-            "UnsafeBlockSigner": "0xc9ad1db6cb756414cda307705a1ee4308e9100ae",
-            "BatchSubmitter": "0xa488310ab2f8aa3294903930023bcab5880cb1ba"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "World Chain Sepolia Testnet",
-          "l2_chain_id": 4801,
-          "PublicRPC": "https://worldchain-sepolia.g.alchemy.com/public",
-          "SequencerRPC": "https://worldchain-sepolia-sequencer.g.alchemy.com",
-          "Explorer": "https://worldchain-sepolia.explorer.alchemy.com/",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000484752",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1721739600,
-            "granite_time": 1726570800,
-            "holocene_time": 1737633600,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 1800,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0xa",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6278018,
-              "hash": "0xd220bbdf24df6d1611f4ece1d08c64feae914ce6299ab2806c864e30a5289201"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xf1deb67ee953f94d8545d2647918687fa8ba1f30fa6103771f11b7c483984070"
-            },
-            "l2_time": 1720547424,
-            "system_config": {
-              "batcherAddress": "0x0f3ff4731d7a10b89ed79ad1fd97844d7f66b96d",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 100000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xc50ba0767a1c0ef69cf1d9cd44de52b08589f691",
-            "L1CrossDomainMessengerProxy": "0x7768c821200554d8f359a8902905ba9ede5659a9",
-            "L1Erc721BridgeProxy": "0x3580505c56f8560e3777e92fb27f70fd20c5b493",
-            "L1StandardBridgeProxy": "0xd7df54b3989855eb66497301a4aaec33dbb3f8de",
-            "L2OutputOracleProxy": "0xc8886f8bab6eaeb215adb5f1c686bf699248300e",
-            "OptimismMintableErc20FactoryProxy": "0x2d272ef54ee8ef5c2ff3523559186580b158cd57",
-            "OptimismPortalProxy": "0xff6eba109271fe6d4237eeed4bab1dd9a77dd1a4",
-            "SystemConfigProxy": "0x166f9406e79a656f12f05247fb8f5dfa6155bcbf",
-            "ProxyAdmin": "0x3a987fe1cb587b0a1808cf9bb7cbe0e341838319",
-            "AnchorStateRegistryProxy": "0x1333d5e5201d760444a399e77b3d337ebdb0dd07",
-            "DelayedWethProxy": "0x4f4b8adf1af4b61bb62f68b7af1c37f8a6311663",
-            "DisputeGameFactoryProxy": "0x8ec1111f67dad6b6a93b3f42dfbc92d81c98449a",
-            "FaultDisputeGame": null,
-            "Mips": "0x69470d6970cd2a006b84b1d4d70179c892cfce01",
-            "PermissionedDisputeGame": "0x552334bf0b124bd89bff744f33ca7e49d44a80ac",
-            "PreimageOracle": "0x92240135b46fc1142da181f550ae8f595b858854"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xe78a0a96c5d6ae6c606418ed4a9ced378cb030a0",
-            "ProxyAdminOwner": "0x945185c01fb641ba3e63a9bdf66575e35a407837",
-            "Guardian": "0xe78a0a96c5d6ae6c606418ed4a9ced378cb030a0",
-            "Challenger": "0x945185c01fb641ba3e63a9bdf66575e35a407837",
-            "Proposer": "0x77a95104e4025fc8b88a6a0f5fb7fae20851e414",
-            "UnsafeBlockSigner": "0x3241a7d28ea74e807a5087ba637fb58d8ddcd078",
-            "BatchSubmitter": "0x0f3ff4731d7a10b89ed79ad1fd97844d7f66b96d"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "arena-z-testnet",
-          "l2_chain_id": 9897,
-          "PublicRPC": "https://rpc.arena-z.t.raas.gelato.cloud",
-          "SequencerRPC": "https://rpc.arena-z.t.raas.gelato.cloud",
-          "Explorer": "https://arena-z.blockscout.com",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000009897",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 1723478400,
-            "holocene_time": 1732633200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0xa",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6410228,
-              "hash": "0x0c9c133c27d12e35a7b3ff2358f2dc1ff5eda8cced373dccb6cf394302bfd135"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xbd3f64b71ff2f6a414afa77068e602b764c45fe399b72de992af2a7787e8227d"
-            },
-            "l2_time": 1722432480,
-            "system_config": {
-              "batcherAddress": "0xabecfbb176fa579ee7e1ed1947e375b118433be0",
-              "overhead": "0xbc",
-              "scalar": "0xf4240",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x5b7996f61650a6f4920f2c8ef4bfaf4f64a07638",
-            "L1CrossDomainMessengerProxy": "0xcc226a3b7b5ec4d4d698418fc2c0492950136ba7",
-            "L1Erc721BridgeProxy": "0x11d7f6f2e59fc12e61dbfafe7790e54cab01b434",
-            "L1StandardBridgeProxy": "0x76a4b2cc5d210729fb3de13cee250663bdac73a6",
-            "L2OutputOracleProxy": "0xf2574585ec7ba515fd86402b84a60d5efb51b0ff",
-            "OptimismMintableErc20FactoryProxy": "0x88404b147e158e65fe7c9e7a9f50dd278f5e5e6e",
-            "OptimismPortalProxy": "0x2188047ad28b78d975ce319dfcda5d06c2a6a68b",
-            "SystemConfigProxy": "0xa3c900d30ee6e906fc085633258d2fe619680884",
-            "ProxyAdmin": "0x554d3431cf89e680610cfbfb9b558777e0a72f39",
-            "AnchorStateRegistryProxy": "0xbb5b16c3ffdb21f67b1d7b1158517ce62d95aa68",
-            "DelayedWethProxy": "0x8a91337fd5113669cc368f2b9d5aed8f6c4458c9",
-            "DisputeGameFactoryProxy": "0xd9e9933cc6ef672c93d2a42494b0d2bf14c05544",
-            "FaultDisputeGame": null,
-            "Mips": "0x379094d2ed496ca4ffaf1b17ad4ba3e152fb8486",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x0e4371a13e53563f7a635380cf2db6ecd620f444"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x776bee5229eb00349d6fc956efad7985ee36804d",
-            "ProxyAdminOwner": "0xb33c6a58c26666f04054e8b0d939e17d6eb1a155",
-            "Guardian": "0x776bee5229eb00349d6fc956efad7985ee36804d",
-            "Challenger": "0x776bee5229eb00349d6fc956efad7985ee36804d",
-            "Proposer": "0xbf80c17ee655837e25208436ed543217899b4bd8",
-            "UnsafeBlockSigner": "0xbbc751e8a6285f22c8b6305d1158071f204dbca4",
-            "BatchSubmitter": "0xabecfbb176fa579ee7e1ed1947e375b118433be0"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "RACE Testnet",
-          "l2_chain_id": 6806,
-          "PublicRPC": "https://racetestnet.io",
-          "SequencerRPC": "https://racetestnet.io",
-          "Explorer": "https://testnet.racescan.io/",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000006806",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": null,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6210400,
-              "hash": "0x28dd1dd74080560ef0b02f8f1ae31d1be75b01a70a5be6ef22e673cec538770f"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x994d67464c3368b8eb6f9770087399486b25d721a1868b95bb37de327b49ab89"
-            },
-            "l2_time": 1719646560,
-            "system_config": {
-              "batcherAddress": "0x584d61a30c7ef1e8d547ee02099dadc487f49889",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x1b573db1000ea419b6de8eb482c6d394179bd1a3",
-            "L1CrossDomainMessengerProxy": "0xdaeab17598938a4f27e50ac771249ad7df12ea7d",
-            "L1Erc721BridgeProxy": "0xbafb1a6e54e7750af29489d65888d1c96dfd66df",
-            "L1StandardBridgeProxy": "0x289179e9d43a35d47239456251f9c2fdbf9fbea2",
-            "L2OutputOracleProxy": "0xccac2b8ffc4f778242105f3a9e6b3ae3f827fc6a",
-            "OptimismMintableErc20FactoryProxy": "0xbd023e7f08ae0274dced397d4b6630d697ac738a",
-            "OptimismPortalProxy": "0xf2891fc6819cdd6bd9221874619bb03a6277d72a",
-            "SystemConfigProxy": "0x07e7a3f25aa73da15bc19b71fef8f5511342a409",
-            "ProxyAdmin": "0x4a0e8415e3eb85e7393445fd8e588283b62216c8",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xe6869af6c871614df04902870bb13d4505e1586c",
-            "ProxyAdminOwner": "0xac78e9b3aa9373ae4be2ba5bc9f716d7a746a65e",
-            "Guardian": "0xe6869af6c871614df04902870bb13d4505e1586c",
-            "Challenger": "0xe6869af6c871614df04902870bb13d4505e1586c",
-            "Proposer": "0x5a145e3f466fd6cc095214c700359df7894bad21",
-            "UnsafeBlockSigner": "0x89ea88ef4ac23f4c7fdc611fc9cd1c50df702c2c",
-            "BatchSubmitter": "0x584d61a30c7ef1e8d547ee02099dadc487f49889"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Cyber Testnet",
-          "l2_chain_id": 111557560,
-          "PublicRPC": "https://rpc.testnet.cyber.co",
-          "SequencerRPC": "https://cyber.alt.technology/",
-          "Explorer": "https://testnet.cyberscan.co/",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000042069",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": null,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 10,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0xa",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 5488109,
-              "hash": "0x0ad7012996ee943369fe592424821845ab115e43a9bc5d4e17bf9493869f98e3"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xd61aa9a43cba806375bec108aba488f00cf784a53a6e5164bc3ef9eb8b169eaf"
-            },
-            "l2_time": 1710470112,
-            "system_config": {
-              "batcherAddress": "0x90bb84339856530192cd002533cd7f1290fc5142",
-              "overhead": "0x834",
-              "scalar": "0xf4240",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x4e9874640d6a670b7f4c7a1370bc303bb46f360f",
-            "L1CrossDomainMessengerProxy": "0xb88ee11d822bec8055f19711458de8593e7117a3",
-            "L1Erc721BridgeProxy": "0x524e85d2b49497561c53efeb4b126aa63883b480",
-            "L1StandardBridgeProxy": "0xaa1bd6d4d8cfd37330a917bc678cb38befaf44e6",
-            "L2OutputOracleProxy": "0xd94ce9e4886a6dcebc7cf993f4b38f5276516643",
-            "OptimismMintableErc20FactoryProxy": "0xcfc893490072f14f19ed6df2b0d985f908acee50",
-            "OptimismPortalProxy": "0x06c9cadb0346c8e142fb8299cef3eb5120d4c9b6",
-            "SystemConfigProxy": "0x43b838aa237b27c4fc953e591594cebb1ca2817f",
-            "ProxyAdmin": "0x6fce62e16720be713e77c954d6f1e6bc8b8d9f48",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": "0x99f0f9b0e7b16b10042e0935ce34f2fcebbe13c1",
-            "FaultDisputeGame": null,
-            "Mips": "0xd0e6c40d8462466633baa2d24796d788a08b2e9f",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0xcef1e04fd7413c4a7287df9099ac57eed48fb8f2"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x66530799037b46913e52e9e0144d15ab6ed954f5",
-            "ProxyAdminOwner": "0x642a102cd63f039930f99b4657f41fd4ad7699d6",
-            "Guardian": "0x66530799037b46913e52e9e0144d15ab6ed954f5",
-            "Challenger": "0x66530799037b46913e52e9e0144d15ab6ed954f5",
-            "Proposer": "0x69ffd6a97141b632631ef7f56ccea6a36f02bd7f",
-            "UnsafeBlockSigner": "0xf6c6d69ad0ec617593bddae9702b3f912621c6fe",
-            "BatchSubmitter": "0x90bb84339856530192cd002533cd7f1290fc5142"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Soneium Testnet Minato",
-          "l2_chain_id": 1946,
-          "PublicRPC": "https://rpc.minato.soneium.org",
-          "SequencerRPC": "https://rpc.minato.soneium.org",
-          "Explorer": "https://soneium-minato.blockscout.com/",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 1734685200,
-          "batch_inbox_address": "0x00ca81e019a5312d404ae7fe8367d30de4c11365",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1730106000,
-            "granite_time": 1730106000,
-            "holocene_time": 1734685200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 1800,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6465975,
-              "hash": "0x87e648e8d219737526cbcbc03dc914256d4f8e13ae13dc0a2ad377d831cd6473"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x7ec49d93fa8f47c00e98cc5965cd3903a8faa9238743d2eba0e0550ab4c45c43"
-            },
-            "l2_time": 1723194336,
-            "system_config": {
-              "batcherAddress": "0xf0ab0441c8f4b89b561ae685b98c6ad5175e0cab",
-              "overhead": "0x0",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x6e8a77673109783001150dfa770e6c662f473da9",
-            "L1CrossDomainMessengerProxy": "0x0184245d202724dc28a2b688952cb56c882c226f",
-            "L1Erc721BridgeProxy": "0x2bfb22cd534a462028771a1ca9d6240166e450c4",
-            "L1StandardBridgeProxy": "0x5f5a404a5edabcdd80db05e8e54a78c9ebf000c2",
-            "L2OutputOracleProxy": "0x710e5286c746ec38beeb7538d0146f60d27be343",
-            "OptimismMintableErc20FactoryProxy": "0x6069bc38c6185f2db0d161f08ec8d1657f6078df",
-            "OptimismPortalProxy": "0x65ea1489741a5d72ffdd8e6485b216bbdcc15af3",
-            "SystemConfigProxy": "0x4ca9608fef202216bc21d543798ec854539baad3",
-            "ProxyAdmin": "0xff9d236641962cebf9dbfb54e7b8e91f99f10db0",
-            "AnchorStateRegistryProxy": "0xa4abeba1612cf731843460791e1a925c84d0991c",
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": "0xb3ad2c38e6e0640d7ce6aa952ab3a60e81bf7a01",
-            "FaultDisputeGame": null,
-            "Mips": "0x4e3db3fa21566ff2ad6e11d1adc129ecf649e47f",
-            "PermissionedDisputeGame": "0x55bc868c07c8cd48446a76966894f4d87844839c",
-            "PreimageOracle": "0xbfebcf9b8855c3e1d01b2ad28db9f59bc6cb6965"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xb278818732e5bebb742dc4aa0617ccd1dec76b65",
-            "ProxyAdminOwner": "0x4d59ccca765e1211bd32aa6f2a037fd37e519a25",
-            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
-            "Challenger": "0xb278818732e5bebb742dc4aa0617ccd1dec76b65",
-            "Proposer": "0xa759a2c80ec4c6421829862da30dd34436114502",
-            "UnsafeBlockSigner": "0x55930859cd7003f32a2ba171297408476532e535",
-            "BatchSubmitter": "0xf0ab0441c8f4b89b561ae685b98c6ad5175e0cab"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Mode Testnet",
-          "l2_chain_id": 919,
-          "PublicRPC": "https://sepolia.mode.network",
-          "SequencerRPC": "https://sepolia.mode.network",
-          "Explorer": "https://sepolia.explorer.mode.network",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 1703203200,
-          "batch_inbox_address": "0xcddae6148da1e003c230e4527f9baedc8a204e7e",
-          "hardfork_configuration": {
-            "canyon_time": 1703203200,
-            "delta_time": 1703203200,
-            "ecotone_time": 1708534800,
-            "fjord_time": 1716998400,
-            "granite_time": 1723478400,
-            "holocene_time": 1732633200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 3778382,
-              "hash": "0x4370cafe528a1b8f2aaffc578094731daf69ff82fd9edc30d2d842d3763f3410"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x13c352562289a88ed33087a51b6b6c859a27709c8555c9def7cb9757c043acad"
-            },
-            "l2_time": 1687867932,
-            "system_config": {
-              "batcherAddress": "0x4e6bd53883107b063c502ddd49f9600dc51b3ddc",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x83d45725d6562d8cd717673d6bb4c67c07dc1905",
-            "L1CrossDomainMessengerProxy": "0xc19a60d9e8c27b9a43527c3283b4dd8edc8be15c",
-            "L1Erc721BridgeProxy": "0x015a8c2e0a5fed579dbb05fd290e413adc6fc24a",
-            "L1StandardBridgeProxy": "0xbc5c679879b2965296756cd959c3c739769995e2",
-            "L2OutputOracleProxy": "0x2634bd65ba27ab63811c74a63118acb312701bfa",
-            "OptimismMintableErc20FactoryProxy": "0x00f7ab8c72d32f55cff15e8901c2f9f2bf29a3c0",
-            "OptimismPortalProxy": "0x320e1580efff37e008f1c92700d1eba47c1b23fd",
-            "SystemConfigProxy": "0x15cd4f6e0ce3b4832b33cb9c6f6fe6fc246754c2",
-            "ProxyAdmin": "0xe7413127f29e050df65ac3fc9335f85bb10091ae",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
-            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
-            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
-            "Challenger": "0x45effbd799ab49122eeeab75b78d9c56a187f9a7",
-            "Proposer": "0xe9e08a478e3a773c1b5d59014a0fdb901e6d1d69",
-            "UnsafeBlockSigner": "0x93a14e6894eeb4ff6a373e1ad4f498c3a207afe4",
-            "BatchSubmitter": "0x4e6bd53883107b063c502ddd49f9600dc51b3ddc"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Funki Sepolia Testnet",
-          "l2_chain_id": 3397901,
-          "PublicRPC": "https://funki-testnet.alt.technology",
-          "SequencerRPC": "https://funki-testnet.alt.technology",
-          "Explorer": "https://sepolia-sandbox.funkichain.com/",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff000000000000000000000000000000000084bb",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": null,
-            "granite_time": null,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 28800,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "alt-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": {
-            "da_challenge_address": null,
-            "da_challenge_window": 1,
-            "da_resolve_window": 1
-          },
-          "genesis": {
-            "l1": {
-              "number": 5853286,
-              "hash": "0x6bc7182e10df2bf35d76362989e10e2c6799c4ceff2eb32741cb804dfab9dd06"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xcebbf8fc7d0fab412866fe1e7df73c721104550ec35e55d173064acb2c0aeac9"
-            },
-            "l2_time": 1715060436,
-            "system_config": {
-              "batcherAddress": "0xda19a4e4d1dbc69bacf13435f08f76ced9b3c245",
-              "overhead": "0xb4",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x6ecc4a306cd20f8041d63b3db8eca46b713cdecc",
-            "L1CrossDomainMessengerProxy": "0x6f82d895e223dde65da28a8bbd14f3ef79cbf3b8",
-            "L1Erc721BridgeProxy": "0x598d245ea85fbfbcece6c62232bbcab688d3f68b",
-            "L1StandardBridgeProxy": "0x1ba82f688ef3c5b4363ff667254ed4dc59e97477",
-            "L2OutputOracleProxy": "0xb25812386d1cb976b50de7387f5cbc10fec3f27c",
-            "OptimismMintableErc20FactoryProxy": "0x8ee8eb6b829c382ca395d35c40dcd2ef8ae57c68",
-            "OptimismPortalProxy": "0xcee7ef4ddf482447fe14c605ea94b37cbe87ca9d",
-            "SystemConfigProxy": "0xd6a01f1ef51d65f023433992a8f62feead35b172",
-            "ProxyAdmin": "0xb3e1f3ab2a22049cc155eba7089ea20a5eab99ca",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": "0x31d0d1d3fc27b3f174e544364e7bb836980162d1",
-            "DisputeGameFactoryProxy": "0xec7c6e35f4e5361d279d5fe7222f3f45a8a83352",
-            "FaultDisputeGame": null,
-            "Mips": "0x71483031c5d2927ea83807d5c88bd8eccfaf292d",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x2de051316aad761a3ebd6ff008d714805bd02c56"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xcdaf106c5531fd27bf27536e4696e325de9f52b8",
-            "ProxyAdminOwner": "0x814973b1ec9eb9172996931de7bf1380bd64a824",
-            "Guardian": "0xdf3d6fa42fe4225e6a042c4ed191d7e5d8252e6f",
-            "Challenger": "0x542a7142093d536bf277fa3b0410883ac4e121dc",
-            "Proposer": "0x0b8aa7c355917016496e999a80f1737ef9c0c962",
-            "UnsafeBlockSigner": "0x5359050acb96c515562896ba71089487138e4bde",
-            "BatchSubmitter": "0xda19a4e4d1dbc69bacf13435f08f76ced9b3c245"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "OP Sepolia Testnet",
-          "l2_chain_id": 11155420,
-          "PublicRPC": "https://sepolia.optimism.io",
-          "SequencerRPC": "https://sepolia-sequencer.optimism.io",
-          "Explorer": "https://sepolia-optimistic.etherscan.io",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xff00000000000000000000000000000011155420",
-          "hardfork_configuration": {
-            "canyon_time": 1699981200,
-            "delta_time": 1703203200,
-            "ecotone_time": 1708534800,
-            "fjord_time": 1716998400,
-            "granite_time": 1723478400,
-            "holocene_time": 1732633200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 4071408,
-              "hash": "0x48f520cf4ddaf34c8336e6e490632ea3cf1e5e93b0b2bc6e917557e31845371b"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"
-            },
-            "l2_time": 1691802540,
-            "system_config": {
-              "batcherAddress": "0x8f23bb38f531600e5d8fddaaec41f13fab46e98c",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x9bfe9c5609311df1c011c47642253b78a4f33f4b",
-            "L1CrossDomainMessengerProxy": "0x58cc85b8d04ea49cc6dbd3cbffd00b4b8d6cb3ef",
-            "L1Erc721BridgeProxy": "0xd83e03d576d23c9aeab8cc44fa98d058d2176d1f",
-            "L1StandardBridgeProxy": "0xfbb0621e0b23b5478b630bd55a5f21f67730b0f1",
-            "L2OutputOracleProxy": null,
-            "OptimismMintableErc20FactoryProxy": "0x868d59ff9710159c2b330cc0fbdf57144dd7a13b",
-            "OptimismPortalProxy": "0x16fc5058f25648194471939df75cf27a2fdc48bc",
-            "SystemConfigProxy": "0x034edd2a225f7f429a63e0f1d2084b9e0a93b538",
-            "ProxyAdmin": "0x189abaaaa82dfc015a588a7dbad6f13b1d3485bc",
-            "AnchorStateRegistryProxy": "0x218cd9489199f321e1177b56385d333c5b598629",
-            "DelayedWethProxy": "0xcdfdc692a53b4ae9f81e0aebd26107da4a71db84",
-            "DisputeGameFactoryProxy": "0x05f9613adb30026ffd634f38e5c4dfd30a197fa1",
-            "FaultDisputeGame": "0xd9d616e4a03a8e7cc962396c9f8d4e3d306097d3",
-            "Mips": "0x47b0e34c1054009e696babaad56165e1e994144d",
-            "PermissionedDisputeGame": "0x98e3f752c7224f8322afa935a4caec3832bb25c9",
-            "PreimageOracle": "0x92240135b46fc1142da181f550ae8f595b858854"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xfd1d2e729ae8eee2e146c033bf4400fe75284301",
-            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
-            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
-            "Challenger": "0xfd1d2e729ae8eee2e146c033bf4400fe75284301",
-            "Proposer": "0x49277ee36a024120ee218127354c4a3591dc90a9",
-            "UnsafeBlockSigner": "0x57cacbb0d30b01eb2462e5dc940c161aff3230d3",
-            "BatchSubmitter": "0x8f23bb38f531600e5d8fddaaec41f13fab46e98c"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Base Sepolia Testnet",
-          "l2_chain_id": 84532,
-          "PublicRPC": "https://sepolia.base.org",
-          "SequencerRPC": "https://sepolia-sequencer.base.org",
-          "Explorer": "https://sepolia-explorer.base.org",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xff00000000000000000000000000000000084532",
-          "hardfork_configuration": {
-            "canyon_time": 1699981200,
-            "delta_time": 1703203200,
-            "ecotone_time": 1708534800,
-            "fjord_time": 1716998400,
-            "granite_time": 1723478400,
-            "holocene_time": 1732633200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0xa",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 4370868,
-              "hash": "0xcac9a83291d4dec146d6f7f69ab2304f23f5be87b1789119a0c5b1e4482444ed"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"
-            },
-            "l2_time": 1695768288,
-            "system_config": {
-              "batcherAddress": "0x6cdebe940bc0f26850285caca097c11c33103e47",
-              "overhead": "0x834",
-              "scalar": "0xf4240",
-              "gasLimit": 25000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x709c2b8ef4a9fefc629a8a2c1af424dc5bd6ad1b",
-            "L1CrossDomainMessengerProxy": "0xc34855f4de64f1840e5686e64278da901e261f20",
-            "L1Erc721BridgeProxy": "0x21efd066e581fa55ef105170cc04d74386a09190",
-            "L1StandardBridgeProxy": "0xfd0bf71f60660e2f608ed56e1659c450eb113120",
-            "L2OutputOracleProxy": null,
-            "OptimismMintableErc20FactoryProxy": "0xb1efb9650ad6d0cc1ed3ac4a0b7f1d5732696d37",
-            "OptimismPortalProxy": "0x49f53e41452c74589e85ca1677426ba426459e85",
-            "SystemConfigProxy": "0xf272670eb55e895584501d564afeb048bed26194",
-            "ProxyAdmin": "0x0389e59aa0a41e4a413ae70f0008e76caa34b1f3",
-            "AnchorStateRegistryProxy": "0x4c8ba32a5dac2a720bb35cedb51d6b067d104205",
-            "DelayedWethProxy": "0x7698b262b7a534912c8366dd8a531672deec634e",
-            "DisputeGameFactoryProxy": "0xd6e6dbf4f7ea0ac412fd8b65ed297e64bb7a06e1",
-            "FaultDisputeGame": "0x8a9ba50a785c3868bef1fd4924b640a5e0ed54cf",
-            "Mips": "0xff760a87e41144b336e29b6d4582427debdb6dee",
-            "PermissionedDisputeGame": "0x593d20c4c69485b95d11507239be2c725ea2a6fd",
-            "PreimageOracle": "0x627f825cbd48c4102d36f287be71f4234426b9e4"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x0fe884546476ddd290ec46318785046ef68a0ba9",
-            "ProxyAdminOwner": "0x0fe884546476ddd290ec46318785046ef68a0ba9",
-            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
-            "Challenger": "0xda3037ff70ac92cd867c683bd807e5a484857405",
-            "Proposer": "0x037637067c1dbe6d2430616d8f54cb774daa5999",
-            "UnsafeBlockSigner": "0xb830b99c95ea32300039624cb567d324d4b1d83c",
-            "BatchSubmitter": "0xfc56e7272eebbba5bc6c544e159483c4a38f8ba3"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Zora Sepolia Testnet",
-          "l2_chain_id": 999999999,
-          "PublicRPC": "https://sepolia.rpc.zora.energy",
-          "SequencerRPC": "https://sepolia.rpc.zora.energy",
-          "Explorer": "https://sepolia.explorer.zora.energy",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xcd734290e4bd0200dac631c7d4b9e8a33234e91f",
-          "hardfork_configuration": {
-            "canyon_time": 1699981200,
-            "delta_time": 1703203200,
-            "ecotone_time": 1708534800,
-            "fjord_time": 1716998400,
-            "granite_time": 1723478400,
-            "holocene_time": 1732633200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 4548041,
-              "hash": "0xf782446a2487d900addb5d466a8597c7c543b59fa9aaa154d413830238f8798a"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x8b17d2d52564a5a90079d9c860e1386272579e87b17ea27a3868513f53facd74"
-            },
-            "l2_time": 1698080004,
-            "system_config": {
-              "batcherAddress": "0x3cd868e221a3be64b161d596a7482257a99d857f",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x27c9392144dfcb6dab113f737356c32435cd1d55",
-            "L1CrossDomainMessengerProxy": "0x1bdbc0ae22bec0c2f08b4dd836944b3e28fe9b7a",
-            "L1Erc721BridgeProxy": "0x16b0a4f451c4cb567703367e587e15ac108e4311",
-            "L1StandardBridgeProxy": "0x5376f1d543dcbb5bd416c56c189e4cb7399fcccb",
-            "L2OutputOracleProxy": "0x2615b481bd3e5a1c0c7ca3da1bdc663e8615ade9",
-            "OptimismMintableErc20FactoryProxy": "0x5f3bdd57f01e88ce2f88f00685d30d6eb51a187c",
-            "OptimismPortalProxy": "0xeffe2c6ca9ab797d418f0d91ea60807713f3536f",
-            "SystemConfigProxy": "0xb54c7bfc223058773cf9b739cc5bd4095184fb08",
-            "ProxyAdmin": "0xe17071f4c216eb189437fbdbcc16bb79c4efd9c2",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
-            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
-            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
-            "Challenger": "0x45effbd799ab49122eeeab75b78d9c56a187f9a7",
-            "Proposer": "0xe8326a5839175de7f467e66d8bb443aa70da1c3e",
-            "UnsafeBlockSigner": "0x3609513933100689bd1f84782529a99239842344",
-            "BatchSubmitter": "0x3cd868e221a3be64b161d596a7482257a99d857f"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Ink Sepolia",
-          "l2_chain_id": 763373,
-          "PublicRPC": "https://rpc-gel-sepolia.inkonchain.com",
-          "SequencerRPC": "https://rpc-gel-sepolia.inkonchain.com",
-          "Explorer": "https://explorer-sepolia.inkonchain.com",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0x004de1914f4f17ac234f5a5bc8a4072a231d44bf",
-          "hardfork_configuration": {
-            "canyon_time": 1699981200,
-            "delta_time": 1703203200,
-            "ecotone_time": 1708534800,
-            "fjord_time": 1716998400,
-            "granite_time": 1723478400,
-            "holocene_time": 1732633200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 1,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6880819,
-              "hash": "0x5fb818b4d3ba100eeb3347c508bca24752ee88f235120e108bd9ee5d1b2ae50b"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xe5fd5cf0be56af58ad5751b401410d6b7a09d830fa459789746a3d0dd1c79834"
-            },
-            "l2_time": 1729003296,
-            "system_config": {
-              "batcherAddress": "0x21e57c21530bc33f12ba96c9ddc135488365002f",
-              "overhead": "0x0",
-              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x3454f9df5e750f1383e58c1cb001401e7a4f3197",
-            "L1CrossDomainMessengerProxy": "0x9fe1d3523f5342535e6e7770ed09ed85dbc1acc2",
-            "L1Erc721BridgeProxy": "0xd1c901bbd7796546a7ba2492e0e199911fae68c7",
-            "L1StandardBridgeProxy": "0x33f60714bbd74d62b66d79213c348614de51901c",
-            "L2OutputOracleProxy": null,
-            "OptimismMintableErc20FactoryProxy": "0x686f782a749d1854f6fa3f948450f4c65c6674f0",
-            "OptimismPortalProxy": "0x5c1d29c6c9c8b0800692acc95d700bcb4966a1d7",
-            "SystemConfigProxy": "0x05c993e60179f28bf649a2bb5b00b5f4283bd525",
-            "ProxyAdmin": "0xd7db319a49362b2328cf417a934300cccb442c8d",
-            "AnchorStateRegistryProxy": "0x89126a987717207d4e990ed2e8880fd170dcea1a",
-            "DelayedWethProxy": "0x180ac451088b8f87006ab0ca98a01507e42ac456",
-            "DisputeGameFactoryProxy": "0x860e626c700af381133d9f4af31412a2d1db3d5d",
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": "0xa8808360f7bc16da81938e5c29400d18bea651c4",
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xbea2bc852a160b8547273660e22f4f08c2fa9bbb",
-            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
-            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
-            "Challenger": "0xfd1d2e729ae8eee2e146c033bf4400fe75284301",
-            "Proposer": "0xb15d792e30c5b7f67cbe5fe9ba76685b537b4543",
-            "UnsafeBlockSigner": "0x43ec5732581d3fae18abb7ce34a796e111dbd1a0",
-            "BatchSubmitter": "0x21e57c21530bc33f12ba96c9ddc135488365002f"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Ethernity Testnet",
-          "l2_chain_id": 233,
-          "PublicRPC": "https://testnet.ethernitychain.io",
-          "SequencerRPC": "https://testnet.ethernitychain.io",
-          "Explorer": "https://testnet.ernscan.io",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 0,
-          "batch_inbox_address": "0xff00000000000000000000000000000000000233",
-          "hardfork_configuration": {
-            "canyon_time": 1699981200,
-            "delta_time": 1703203200,
-            "ecotone_time": 1708534800,
-            "fjord_time": 1716998400,
-            "granite_time": 1723478400,
-            "holocene_time": 1732633200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6037466,
-              "hash": "0x2d9c0b883cfc901f509bd94953c283c477adc57c8a20e234029244e68f00142a"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0x4715665848c513c54d71a3e60700743f2b37ec21df9b9d0b8eefee4c30cd557a"
-            },
-            "l2_time": 1717499232,
-            "system_config": {
-              "batcherAddress": "0x973a9e30d6d11355a459a69e7cbfba61c7627736",
-              "overhead": "0xbc",
-              "scalar": "0xf4240",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x2d34a143d7bead8f75479c841e3aabf6c4afdec8",
-            "L1CrossDomainMessengerProxy": "0x1c8b6a6f3e3612c79e62460a6e44c24d1eff2fda",
-            "L1Erc721BridgeProxy": "0xbf0d43e12ef74dc21917e1d6175702ad673e1283",
-            "L1StandardBridgeProxy": "0xfd1a12b7a04b13c031d8b075ba5b9080a2cf246f",
-            "L2OutputOracleProxy": "0x11118536f94bc7c98bbaf9194be13fc1987293cd",
-            "OptimismMintableErc20FactoryProxy": "0x0d085b528e1f9f48018b46f9ac3696f16b7007f9",
-            "OptimismPortalProxy": "0x1f24d471ef7291c7f97dbd2f76299b30d3e3b6e3",
-            "SystemConfigProxy": "0x7c957fec1f6b3d1024442e989cb08b8f2285686c",
-            "ProxyAdmin": "0x7ea23a9df2e3e491757a9ff6c32083a44be560e6",
-            "AnchorStateRegistryProxy": "0xb065b32927c3114c0e0df16d3887f4fd12ef7117",
-            "DelayedWethProxy": "0x21676d682f11f3e46cce1797b19205dda78f0f6c",
-            "DisputeGameFactoryProxy": "0x64d0bce6ed7c16cac7817f3597758e31afacd01b",
-            "FaultDisputeGame": null,
-            "Mips": "0xfed5edd40bfbefc99432bbb4f2cecd450c4c8675",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x4abd4d6d11c5d7ce392b2b0544e37314710f53c2"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x097955a7aa7966d55d781688aa1493493ab513af",
-            "ProxyAdminOwner": "0x5a19d3afd327bd01d390eb52c11c2a9a79bcfb32",
-            "Guardian": "0x097955a7aa7966d55d781688aa1493493ab513af",
-            "Challenger": "0x097955a7aa7966d55d781688aa1493493ab513af",
-            "Proposer": "0xbf1374d8c2e98074368326786343f1ade19d5ccd",
-            "UnsafeBlockSigner": "0xdb0c6821a033eb9dc152bb008f42ebad0eaddca3",
-            "BatchSubmitter": "0x973a9e30d6d11355a459a69e7cbfba61c7627736"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Lisk Sepolia Testnet",
-          "l2_chain_id": 4202,
-          "PublicRPC": "https://rpc.sepolia-api.lisk.com",
-          "SequencerRPC": "https://rpc.sepolia-api.lisk.com",
-          "Explorer": "https://sepolia-blockscout.lisk.com",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000004202",
-          "hardfork_configuration": {
-            "canyon_time": 1705312994,
-            "delta_time": 1705312994,
-            "ecotone_time": 1708534800,
-            "fjord_time": 1716998400,
-            "granite_time": 1723478400,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0xa",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 5089851,
-              "hash": "0x7d9d6dcec39efe182119f41b1bd2aa7b35b82e43927522afea86d210a4eace4b"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xead3e6ddd08ae7e27fd952b74ceb468ba889047ac96b351dd13bd55e5faf3372"
-            },
-            "l2_time": 1705312992,
-            "system_config": {
-              "batcherAddress": "0x246e119a5bcc2875161b23e4e602e25cece96e37",
-              "overhead": "0x834",
-              "scalar": "0xf4240",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x27bb4a7cd8fb20cb816bf4aac668bf841bb3d5d3",
-            "L1CrossDomainMessengerProxy": "0x857824e6234f7733eca4e9a76804fd1afa1a3a2c",
-            "L1Erc721BridgeProxy": "0xb4e988cf1ad8c361d56118437502a8f11c7faa01",
-            "L1StandardBridgeProxy": "0x1fb30e446ea791cd1f011675e5f3f5311b70faf5",
-            "L2OutputOracleProxy": "0xa0e35f56c318de1bd5d9ca6a94fe7e37c5663348",
-            "OptimismMintableErc20FactoryProxy": "0x269d632c1e518a922c30c749cfd3f82eb5c779b0",
-            "OptimismPortalProxy": "0xe3d90f21490686ec7ef37be788e02dfc12787264",
-            "SystemConfigProxy": "0xf54791059df4a12ba461b881b4080ae81a1d0ac0",
-            "ProxyAdmin": "0x5db9f05921d8d5a6a157f6f49c411cc0e46c6330",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": "0x9aa3890a87e6bd2cb85dad1a5d8b0a9d669e658a",
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x19de6d30bf43654b7244b8ada135e1aa639bf091",
-            "ProxyAdminOwner": "0x465874903125f26316c730ae84862606a3326ca5",
-            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
-            "Challenger": "0x19de6d30bf43654b7244b8ada135e1aa639bf091",
-            "Proposer": "0xbbd3a1d90b0ef416581acdc6a72046b38d3af9ad",
-            "UnsafeBlockSigner": "0x99804980804e9ebe78db89c049ffe36ceaaef654",
-            "BatchSubmitter": "0x246e119a5bcc2875161b23e4e602e25cece96e37"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Shape Sepolia Testnet",
-          "l2_chain_id": 11011,
-          "PublicRPC": "https://sepolia.shape.network/",
-          "SequencerRPC": "https://shape-sepolia-sequencer.g.alchemy.com",
-          "Explorer": "https://shape-sepolia.explorer.alchemy.com/",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000011011",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1721732400,
-            "granite_time": 1727197200,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 1800,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6151675,
-              "hash": "0x0e1156bae935f43af44f8d3e011275b8aeab57acd83cbd71d92903d3c9b29cf3"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xcb3558db049390808cbde6b82a48d06ed98d3fe959e088ac20ae56174595cfce"
-            },
-            "l2_time": 1718936160,
-            "system_config": {
-              "batcherAddress": "0x6ff556fa7cafec55ae77c5c1d58a010be75f9991",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x42721d8512d62aa26b2cfa1ae18beed5a9ab1337",
-            "L1CrossDomainMessengerProxy": "0xf9f730650e1ab4d23e2ac983934271ca7c5ef293",
-            "L1Erc721BridgeProxy": "0x19f02c55254d2644ef94f30c74a932d64e1d4f86",
-            "L1StandardBridgeProxy": "0x341ab1dafdfb73b3d6d075ef10b29e3cacb2a653",
-            "L2OutputOracleProxy": "0x532ddced3440eab81c529ac8b0d7e429b5c05c52",
-            "OptimismMintableErc20FactoryProxy": "0x46085e2e648488e49fbeaf6544b8e9dc96df8bdd",
-            "OptimismPortalProxy": "0xff8ca2b4d8122e41441f7ccdcf61b8692198bd1e",
-            "SystemConfigProxy": "0xa1ac91ed91ebe40e00d61e233c8026318b4da5fb",
-            "ProxyAdmin": "0xd60a706bf6108f090d055787b9b353fa7eee1355",
-            "AnchorStateRegistryProxy": "0x41ea3c370896632121cdde1b94a4eccf23da4532",
-            "DelayedWethProxy": "0x7cc9ca91ba4f92f4c967e93a1aad97beb18d3877",
-            "DisputeGameFactoryProxy": "0x93eaa7a1e7d7af7ed9d612f9957988c8631c33e8",
-            "FaultDisputeGame": null,
-            "Mips": "0xacf1ed7357e41f652407ae6cfe1024705c758c38",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x8f3b1c59ed4439ebf564604aa4b93130da4cd1d5"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xa9abe4af69bea2f381ca600f625eb3e6b7559266",
-            "ProxyAdminOwner": "0x4c4526c8c55c4e1a6f2aaf91e37f07c97786e0f5",
-            "Guardian": "0xa9abe4af69bea2f381ca600f625eb3e6b7559266",
-            "Challenger": "0xa9abe4af69bea2f381ca600f625eb3e6b7559266",
-            "Proposer": "0xf8ed03b83c15aa3d0b52095f3c9971225948b777",
-            "UnsafeBlockSigner": "0xbb4f4b3a46361653be9db255d8ff2d004f0fb248",
-            "BatchSubmitter": "0x6ff556fa7cafec55ae77c5c1d58a010be75f9991"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Metal L2 Testnet",
-          "l2_chain_id": 1740,
-          "PublicRPC": "https://testnet.rpc.metall2.com",
-          "SequencerRPC": "https://testnet.rpc.metall2.com",
-          "Explorer": "https://testnet.explorer.metall2.com",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": true,
-          "SuperchainTime": 1708534800,
-          "batch_inbox_address": "0x24567b64a86a4c966655fba6502a93dfb701e316",
-          "hardfork_configuration": {
-            "canyon_time": 1708129622,
-            "delta_time": 1708385400,
-            "ecotone_time": 1708534800,
-            "fjord_time": 1716998400,
-            "granite_time": 1723478400,
-            "holocene_time": 1732633200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 5304030,
-              "hash": "0x6a10927c70985f75898c48235b620acb2a48e9c777a40022f9dbad1b0c96a9c1"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xd24cf8e46b189b0c128dab4e46168520e3a4cdd390b239e8cc1e5abd22a629ae"
-            },
-            "l2_time": 1708129620,
-            "system_config": {
-              "batcherAddress": "0xdb80eca386ac72a55510e33cf9cf7533e75916ee",
-              "overhead": "0xbc",
-              "scalar": "0xa6fe0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0x394f844b9a0fc876935d1b0b791d9e94ad905e8b",
-            "L1CrossDomainMessengerProxy": "0x5d335aa7d93102110879e3b54985c5f08146091e",
-            "L1Erc721BridgeProxy": "0x5d6ce6917dbeeacf010c96bffdabe89e33a30309",
-            "L1StandardBridgeProxy": "0x21530aadf4dcfb9c477171400e40d4ef615868be",
-            "L2OutputOracleProxy": "0x75a6b961c8da942ee03ca641b09c322549f6fa98",
-            "OptimismMintableErc20FactoryProxy": "0x49ff2c4be882298e8ca7decd195c207c42b45f66",
-            "OptimismPortalProxy": "0x01d4dfc994878682811b2980653d03e589f093cb",
-            "SystemConfigProxy": "0x5d63a8dc2737ce771aa4a6510d063b6ba2c4f6f2",
-            "ProxyAdmin": "0xf7bc4b3a78c7dd8be9b69b3128eeb0d6776ce18a",
-            "AnchorStateRegistryProxy": null,
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": null,
-            "FaultDisputeGame": null,
-            "Mips": null,
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": null
-          },
-          "Roles": {
-            "SystemConfigOwner": "0x23ba22dd7923f3a3f2495bb32a6f3c9b9cd1ec6c",
-            "ProxyAdminOwner": "0x1eb2ffc903729a0f03966b917003800b145f56e2",
-            "Guardian": "0x7a50f00e8d05b95f98fe38d8bee366a7324dcf7e",
-            "Challenger": "0x45effbd799ab49122eeeab75b78d9c56a187f9a7",
-            "Proposer": null,
-            "UnsafeBlockSigner": null,
-            "BatchSubmitter": "0xdb80eca386ac72a55510e33cf9cf7533e75916ee"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Unichain Sepolia Testnet",
-          "l2_chain_id": 1301,
-          "PublicRPC": "https://sepolia.unichain.org",
-          "SequencerRPC": "https://sepolia-sequencer.unichain.org",
-          "Explorer": "https://sepolia.uniscan.xyz",
-          "SuperchainLevel": 1,
-          "GovernedByOptimism": false,
-          "SuperchainTime": 1734559200,
-          "batch_inbox_address": "0xff00000000000000000000000000000000001301",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 0,
-            "granite_time": 0,
-            "holocene_time": 1734559200,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 1,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6728364,
-              "hash": "0x81719966c43c08d616a832331500633db68006f5e8c0b575a6faf1704ad350c0"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xb7fe0bc9f98ca03294ca0094ff9374cc3e64130b6ec85850d6e260191f48bfe7"
-            },
-            "l2_time": 1726852428,
-            "system_config": {
-              "batcherAddress": "0x4ab3387810ef500bfe05a49dc53a44c222cbab3e",
-              "overhead": "0x0",
-              "scalar": "0x10000000000000000000000000000000000000000000000000dbba0000007d0",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xef1295ed471dfec101691b946fb6b4654e88f98a",
-            "L1CrossDomainMessengerProxy": "0x448a37330a60494e666f6dd60ad48d930aeba381",
-            "L1Erc721BridgeProxy": "0x4696b5e042755103fe558738bcd1ecee7a45ebfe",
-            "L1StandardBridgeProxy": "0xea58fca6849d79ead1f26608855c2d6407d54ce2",
-            "L2OutputOracleProxy": null,
-            "OptimismMintableErc20FactoryProxy": "0xdf7977c3005730329a160637e8cb9f1675a4d9be",
-            "OptimismPortalProxy": "0x0d83dab629f0e0f9d36c0cbc89b69a489f0751bd",
-            "SystemConfigProxy": "0xaee94b9ab7752d3f7704bde212c0c6a0b701571d",
-            "ProxyAdmin": "0x2bf403e5353a7a082ef6bb3ae2be3b866d8d3ea4",
-            "AnchorStateRegistryProxy": "0xf971f1b0d80eb769577135b490b913825bfcf00b",
-            "DelayedWethProxy": null,
-            "DisputeGameFactoryProxy": "0xeff73e5aa3b9aec32c659aa3e00444d20a84394b",
-            "FaultDisputeGame": null,
-            "Mips": "0x1cec5b1954302f6faf45515145c72d7f7266546c",
-            "PermissionedDisputeGame": "0x2a82958845ddc647ce1d45f44a7038d6a2d363ac",
-            "PreimageOracle": "0xad0a6f4f1503048c34d90df845c37c876407355a"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xb6185370e3db2472ec7ec4a2826954d2d4923b9f",
-            "ProxyAdminOwner": "0xd363339ee47775888df411a163c586a8bdea9dbf",
-            "Guardian": "0xd032d9e1f3b3ca6362ec56fbc9d689565f759825",
-            "Challenger": "0x921d59f383e9b86b3161a356013b6f8b40cf43c4",
-            "Proposer": "0xa25b0ef1cc3ee12a0a167b5bf44db1a9c166474e",
-            "UnsafeBlockSigner": "0x565b71025ab4de80aca33c62e51439af56301493",
-            "BatchSubmitter": "0x4ab3387810ef500bfe05a49dc53a44c222cbab3e"
-          },
-          "GasPayingToken": null
-        },
-        {
-          "Name": "Binary Sepolia",
-          "l2_chain_id": 625,
-          "PublicRPC": "https://rpc.testnet.thebinaryholdings.com",
-          "SequencerRPC": "https://sequencer.rpc.bnry.testnet.zeeve.net",
-          "Explorer": "https://explorer.sepolia.thebinaryholdings.com",
-          "SuperchainLevel": 0,
-          "GovernedByOptimism": false,
-          "SuperchainTime": null,
-          "batch_inbox_address": "0xff00000000000000000000000000000000042069",
-          "hardfork_configuration": {
-            "canyon_time": 0,
-            "delta_time": 0,
-            "ecotone_time": 0,
-            "fjord_time": 1723204838,
-            "granite_time": 1723545055,
-            "holocene_time": null,
-            "isthmus_time": null,
-            "interop_time": null
-          },
-          "block_time": 2,
-          "seq_window_size": 3600,
-          "max_sequencer_drift": 600,
-          "DataAvailabilityType": "eth-da",
-          "optimism": {
-            "eip1559Elasticity": "0x6",
-            "eip1559Denominator": "0x32",
-            "eip1559DenominatorCanyon": "0xfa"
-          },
-          "alt_da": null,
-          "genesis": {
-            "l1": {
-              "number": 6092340,
-              "hash": "0x8d457519705ad17cf812d7cd4cfe5726eca8249f9e5f40a1d19992b07c2521ce"
-            },
-            "l2": {
-              "number": 0,
-              "hash": "0xf1c38d92222758e1ea0c9c7ae1f7f2dfd0e3e747609f1c2d5a41ecfc5e84aba9"
-            },
-            "l2_time": 1718195040,
-            "system_config": {
-              "batcherAddress": "0x9cf89f8cb7cc94c579426f967d9517cd2e9adf29",
-              "overhead": "0x0",
-              "scalar": "0x10000000000000000000000000000000000000000000000000c5fc500000558",
-              "gasLimit": 30000000,
-              "baseFeeScalar": null,
-              "blobBaseFeeScalar": null,
-              "eip1559Denominator": null,
-              "eip1559Elasticity": null
-            }
-          },
-          "Addresses": {
-            "AddressManager": "0xd1d82d6fc94962fe25912c181375352d4a10c6f0",
-            "L1CrossDomainMessengerProxy": "0x33dc556a5df0b8998dc2640c78e531ae1db7925d",
-            "L1Erc721BridgeProxy": "0x7c95eebea6f68875b4093d9c2211fd26067a808f",
-            "L1StandardBridgeProxy": "0x3b78c3b41b3e3fc6bdf0bd3060c9e2471401c098",
-            "L2OutputOracleProxy": "0xf3699f96cbdd3868b64352669805d96d1fb6431d",
-            "OptimismMintableErc20FactoryProxy": "0xd47e937d602ffba8597b4f042c7a49e1149392fc",
-            "OptimismPortalProxy": "0xfbed910ca54f013bfea67bd4dc836263bdd0b46c",
-            "SystemConfigProxy": "0x1a6d0312faaaca2bf818660f164450176c6205c9",
-            "ProxyAdmin": "0xf42cff60b92a151911d99f3ed36ba1266511fd43",
-            "AnchorStateRegistryProxy": "0xb86ec23019c6c3f2fbc38502d26b7009d2a300be",
-            "DelayedWethProxy": "0x017e8a21e37ae4bfc482170656b1ebf8390bf880",
-            "DisputeGameFactoryProxy": "0x096b38bdc80b5bf5b5fb4e1a75ae38bda520474a",
-            "FaultDisputeGame": null,
-            "Mips": "0xb51ffe0a519291cbc0080a4f497a2bb4ac0a1c04",
-            "PermissionedDisputeGame": null,
-            "PreimageOracle": "0x029e58272e3b5f7b69aa4455473fcc8c8b8deac3"
-          },
-          "Roles": {
-            "SystemConfigOwner": "0xd7e60cd8fbea5142a207042c477e1359df5fa688",
-            "ProxyAdminOwner": "0x5a11a7a6ca68819c601a4136bfbdfba26d5f043e",
-            "Guardian": "0xd7e60cd8fbea5142a207042c477e1359df5fa688",
-            "Challenger": "0xd7e60cd8fbea5142a207042c477e1359df5fa688",
-            "Proposer": "0x6087ec0371c2950d018ec97d8a1573d412dfbdbe",
-            "UnsafeBlockSigner": "0x0f68fc933d50f719abfbd680f56c22277e2f307c",
-            "BatchSubmitter": "0x9cf89f8cb7cc94c579426f967d9517cd2e9adf29"
-          },
-          "GasPayingToken": "0x46d878bf7bf62ec542953cb89ac0bf58d991181e"
         }
       ]
     }


### PR DESCRIPTION
### Description

Previously, we had a bunch of `[BOT] Update Submodules` prs that just re-ordered chains and superchains in the output `configs.json` artifact.

This PR fixes this by sorting superchains by name and chains by their l2 chain id. This should reduce the frequency of `[BOT] Update Submodules` prs since there won't be a sorting diff.