### PR TITLE
chore(rpc): Test Coverage

### DIFF
--- a/crates/rpc/src/attributes.rs
+++ b/crates/rpc/src/attributes.rs
@@ -40,3 +40,21 @@ impl OpAttributesWithParent {
         self.is_last_in_span
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_op_attributes_with_parent() {
+        let attributes = OpPayloadAttributes::default();
+        let parent = L2BlockInfo::default();
+        let is_last_in_span = true;
+        let op_attributes_with_parent =
+            OpAttributesWithParent::new(attributes.clone(), parent, is_last_in_span);
+
+        assert_eq!(op_attributes_with_parent.attributes(), &attributes);
+        assert_eq!(op_attributes_with_parent.parent(), &parent);
+        assert_eq!(op_attributes_with_parent.is_last_in_span(), is_last_in_span);
+    }
+}

--- a/crates/rpc/src/net.rs
+++ b/crates/rpc/src/net.rs
@@ -265,9 +265,34 @@ impl core::fmt::Display for Direction {
 }
 
 #[cfg(test)]
-#[cfg(feature = "serde")]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_connectedness_from_u8() {
+        assert_eq!(Connectedness::from(0), Connectedness::NotConnected);
+        assert_eq!(Connectedness::from(1), Connectedness::Connected);
+        assert_eq!(Connectedness::from(2), Connectedness::CanConnect);
+        assert_eq!(Connectedness::from(3), Connectedness::CannotConnect);
+        assert_eq!(Connectedness::from(4), Connectedness::Limited);
+        assert_eq!(Connectedness::from(5), Connectedness::NotConnected);
+    }
+
+    #[test]
+    fn test_connectedness_display() {
+        assert_eq!(Connectedness::NotConnected.to_string(), "Not Connected");
+        assert_eq!(Connectedness::Connected.to_string(), "Connected");
+        assert_eq!(Connectedness::CanConnect.to_string(), "Can Connect");
+        assert_eq!(Connectedness::CannotConnect.to_string(), "Cannot Connect");
+        assert_eq!(Connectedness::Limited.to_string(), "Limited");
+    }
+
+    #[test]
+    fn test_direction_display() {
+        assert_eq!(Direction::Unknown.to_string(), "Unknown");
+        assert_eq!(Direction::Inbound.to_string(), "Inbound");
+        assert_eq!(Direction::Outbound.to_string(), "Outbound");
+    }
 
     #[test]
     #[cfg(feature = "serde")]

--- a/crates/rpc/src/net.rs
+++ b/crates/rpc/src/net.rs
@@ -267,6 +267,7 @@ impl core::fmt::Display for Direction {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
 
     #[test]
     fn test_connectedness_from_u8() {

--- a/crates/rpc/src/superchain.rs
+++ b/crates/rpc/src/superchain.rs
@@ -314,6 +314,62 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_protocol_version_display() {
+        assert_eq!(
+            ProtocolVersion::V0(ProtocolVersionFormatV0 {
+                build: B64::from_slice(&[0x61, 0x62, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00]),
+                major: 42,
+                minor: 0,
+                patch: 2,
+                pre_release: 0,
+            })
+            .display(),
+            "v42.0.2+0x6162010000000000"
+        );
+    }
+
+    #[test]
+    fn test_protocol_version_accessors() {
+        let inner = ProtocolVersionFormatV0 {
+            build: B64::from_slice(&[0x61, 0x62, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            major: 42,
+            minor: 0,
+            patch: 2,
+            pre_release: 0,
+        };
+        let protocol_version = ProtocolVersion::V0(inner);
+
+        assert_eq!(
+            protocol_version.build(),
+            B64::from_slice(&[0x61, 0x62, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00])
+        );
+        assert_eq!(protocol_version.major(), 42);
+        assert_eq!(protocol_version.minor(), 0);
+        assert_eq!(protocol_version.patch(), 2);
+        assert_eq!(protocol_version.pre_release(), 0);
+        assert_eq!(protocol_version.inner(), inner);
+        assert_eq!(protocol_version.as_v0(), Some(inner));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_protocol_version_serde() {
+        let raw_protocol_version = r#"
+            "0x000000000000000061620100000000000000002a000000000000000200000000"
+        "#;
+        let protocol_version = ProtocolVersion::V0(ProtocolVersionFormatV0 {
+            build: B64::from_slice(&[0x61, 0x62, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            major: 42,
+            minor: 0,
+            patch: 2,
+            pre_release: 0,
+        });
+
+        let encoded = serde_json::to_string(&protocol_version).unwrap();
+        assert_eq!(encoded, raw_protocol_version.trim());
+    }
+
+    #[test]
     fn test_protocol_version_encode_decode() {
         let test_cases = [
             (


### PR DESCRIPTION
### Description

Adds test coverage to the `maili-rpc` crate.