### PR TITLE
chore: remove pre-release-hook

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -5,6 +5,4 @@ allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
 shared-version = true
-pre-release-commit-message = "chore: release {{version}}"
 tag-prefix = "" # tag only once instead of per every crate
-pre-release-hook = ["sh", "-c", "$WORKSPACE_ROOT/scripts/changelog.sh --tag {{version}}"]


### PR DESCRIPTION
For [OP Succinct](https://github.com/succinctlabs/op-succinct), we need to be able to generate a reproducible ELF (RISC-V binary) of the program, so that rollups using OP Succinct are able to refer to the canonical program. This is similar to the [reproducible prestate builds](https://github.com/op-rs/kona/blob/ec85a08ef93007bdd65f4b6daa2811a5275c116b/docker/fpvm-prestates/README.md) for FPVM's that OP will use.

One issue we've noticed is that there's something in maili that's causing inconsistent builds. I saw this changelog.sh which emits timestamp and thought it might be the cause. I'm not really confident with the root cause of inconsistent builds, but when I removed the pre-release-hook from release.toml, the issue went away.