### PR TITLE
fix(registry): Only bind with MAILI_BIND

### DIFF
--- a/crates/registry/Justfile
+++ b/crates/registry/Justfile
@@ -6,7 +6,7 @@ default:
 
 # Generate file bindings
 bind:
-  cargo build
+  MAILI_BIND=true cargo build
 
 # Update the `superchain-registry` git submodule source
 source:

--- a/crates/registry/build.rs
+++ b/crates/registry/build.rs
@@ -3,13 +3,15 @@
 use maili_genesis::{ChainConfig, Superchain, SuperchainConfig, Superchains};
 
 fn main() {
-    // Get the directory of this file from the environment
-    let src_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    // Check if the filesystem is read-only
-    if std::path::Path::new(&src_dir).metadata().unwrap().permissions().readonly() {
+    // If the `MAILI_BIND` environment variable is _not_ set, then return early.
+    let maili_bind: bool =
+        std::env::var("MAILI_BIND").unwrap_or_else(|_| "false".to_string()) == "true";
+    if !maili_bind {
         return;
     }
+
+    // Get the directory of this file from the environment
+    let src_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     // Check if the `superchain-registry` directory exists
     let superchain_registry = format!("{}/superchain-registry", src_dir);


### PR DESCRIPTION
### Description

Fixes the `maili-registry` build script to _only_ bind when the `MAILI_BIND` environment variable is set to "true".

Otherwise return early from the script.