### PR TITLE
chore(genesis): Remove std restriction for genesis tests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,6 @@
 # ref: https://docs.codecov.com/docs/codecovyml-reference
 coverage:
-  range: 80..100
+  range: 90..100
   round: down
   precision: 1
   status:

--- a/crates/genesis/src/chain/addresses.rs
+++ b/crates/genesis/src/chain/addresses.rs
@@ -6,7 +6,7 @@ use alloy_primitives::Address;
 ///
 /// See: <https://github.com/ethereum-optimism/superchain-registry/blob/8ff62ada16e14dd59d0fb94ffb47761c7fa96e01/ops/internal/config/chain.go#L156-L175>
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "PascalCase"))]
 pub struct AddressList {

--- a/crates/genesis/src/chain/altda.rs
+++ b/crates/genesis/src/chain/altda.rs
@@ -7,7 +7,7 @@ use alloy_primitives::Address;
 ///
 /// See: <https://github.com/ethereum-optimism/superchain-registry/blob/8ff62ada16e14dd59d0fb94ffb47761c7fa96e01/ops/internal/config/chain.go#L133-L138>
 #[derive(Debug, Clone, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AltDAConfig {
     /// AltDA challenge address

--- a/crates/genesis/src/chain/config.rs
+++ b/crates/genesis/src/chain/config.rs
@@ -24,7 +24,7 @@ use crate::{
 /// [ccg]: https://github.com/ethereum-optimism/op-geth/blob/optimism/params/config.go#L342
 /// [ccr]: https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/superchain.go#L80
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainConfig {
     /// Chain name (e.g. "Base")

--- a/crates/genesis/src/chain/hardfork.rs
+++ b/crates/genesis/src/chain/hardfork.rs
@@ -4,7 +4,7 @@
 ///
 /// See: <https://github.com/ethereum-optimism/superchain-registry/blob/8ff62ada16e14dd59d0fb94ffb47761c7fa96e01/ops/internal/config/chain.go#L102-L110>
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HardForkConfiguration {
     /// Canyon hardfork activation time

--- a/crates/genesis/src/chain/roles.rs
+++ b/crates/genesis/src/chain/roles.rs
@@ -6,7 +6,7 @@ use alloy_primitives::Address;
 ///
 /// See: <https://github.com/ethereum-optimism/superchain-registry/blob/8ff62ada16e14dd59d0fb94ffb47761c7fa96e01/ops/internal/config/chain.go#L146-L154>
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "PascalCase"))]
 pub struct Roles {
@@ -27,6 +27,7 @@ pub struct Roles {
 }
 
 #[cfg(test)]
+#[cfg(feature = "serde")]
 mod tests {
     use super::*;
 

--- a/crates/genesis/src/genesis.rs
+++ b/crates/genesis/src/genesis.rs
@@ -18,7 +18,7 @@ pub struct ChainGenesis {
     pub system_config: Option<SystemConfig>,
 }
 
-#[cfg(any(test, feature = "arbitrary"))]
+#[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for ChainGenesis {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let system_config = Option::<SystemConfig>::arbitrary(u)?;

--- a/crates/genesis/src/lib.rs
+++ b/crates/genesis/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/crates/genesis/src/params.rs
+++ b/crates/genesis/src/params.rs
@@ -115,7 +115,7 @@ pub const OP_MAINNET_BASE_FEE_CONFIG: BaseFeeConfig = BaseFeeConfig {
 
 /// Optimism Base Fee Configuration
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseFeeConfig {
     /// EIP 1559 Elasticity Parameter
@@ -188,6 +188,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_base_fee_config_ser() {
         let config = OP_MAINNET_BASE_FEE_CONFIG;
         let raw_str = serde_json::to_string(&config).unwrap();
@@ -198,6 +199,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_base_fee_config_serde_strs() {
         let raw_str: &'static str = r#"{"eip1559Elasticity":"6","eip1559Denominator":"50","eip1559DenominatorCanyon":"250"}"#;
         let config: BaseFeeConfig = serde_json::from_str(raw_str).unwrap();
@@ -205,6 +207,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_base_fee_config_serde_raw_number() {
         let raw_str: &'static str =
             r#"{"eip1559Elasticity":6,"eip1559Denominator":50,"eip1559DenominatorCanyon":250}"#;
@@ -213,6 +216,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_base_fee_config_serde_hex() {
         let raw_str: &'static str = r#"{"eip1559Elasticity":"0x6","eip1559Denominator":"0x32","eip1559DenominatorCanyon":"0xfa"}"#;
         let config: BaseFeeConfig = serde_json::from_str(raw_str).unwrap();

--- a/crates/genesis/src/rollup.rs
+++ b/crates/genesis/src/rollup.rs
@@ -141,7 +141,7 @@ pub struct RollupConfig {
     pub interop_message_expiry_window: u64,
 }
 
-#[cfg(any(test, feature = "arbitrary"))]
+#[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for RollupConfig {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         use crate::{
@@ -370,16 +370,19 @@ impl RollupConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{SystemConfig, OP_MAINNET_BASE_FEE_PARAMS, OP_MAINNET_BASE_FEE_PARAMS_CANYON};
-    use alloy_eips::BlockNumHash;
     #[cfg(feature = "serde")]
-    use alloy_primitives::U256;
-    use alloy_primitives::{address, b256};
-    use arbitrary::Arbitrary;
-    use rand::Rng;
+    use crate::{SystemConfig, OP_MAINNET_BASE_FEE_PARAMS, OP_MAINNET_BASE_FEE_PARAMS_CANYON};
+    #[cfg(feature = "serde")]
+    use alloy_eips::BlockNumHash;
+    use alloy_primitives::address;
+    #[cfg(feature = "serde")]
+    use alloy_primitives::{b256, U256};
 
     #[test]
+    #[cfg(feature = "arbitrary")]
     fn test_arbitrary_rollup_config() {
+        use arbitrary::Arbitrary;
+        use rand::Rng;
         let mut bytes = [0u8; 1024];
         rand::rng().fill(bytes.as_mut_slice());
         RollupConfig::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();

--- a/crates/genesis/src/superchain/level.rs
+++ b/crates/genesis/src/superchain/level.rs
@@ -4,7 +4,7 @@
 ///
 /// See: <https://github.com/ethereum-optimism/superchain-registry/blob/8ff62ada16e14dd59d0fb94ffb47761c7fa96e01/ops/internal/config/chain.go#L14-L20>
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr))]
 #[repr(u8)]
 pub enum SuperchainLevel {

--- a/crates/genesis/src/system/config.rs
+++ b/crates/genesis/src/system/config.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// System configuration.
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct SystemConfig {
@@ -127,10 +127,9 @@ mod test {
     use crate::CONFIG_UPDATE_EVENT_VERSION_0;
     use alloc::vec;
     use alloy_primitives::{address, b256, hex, LogData, B256};
-    use arbitrary::Arbitrary;
-    use rand::Rng;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_system_config_alias() {
         let sc_str: &'static str = r#"{
           "batcherAddress": "0x6887246668a3b87F54DeB3b94Ba47a6f63F32985",
@@ -152,7 +151,10 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "arbitrary")]
     fn test_arbitrary_system_config() {
+        use arbitrary::Arbitrary;
+        use rand::Rng;
         let mut bytes = [0u8; 1024];
         rand::rng().fill(bytes.as_mut_slice());
         SystemConfig::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap();

--- a/crates/genesis/src/updates/batcher.rs
+++ b/crates/genesis/src/updates/batcher.rs
@@ -54,6 +54,7 @@ impl TryFrom<&SystemConfigLog> for BatcherUpdate {
 mod tests {
     use super::*;
     use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use alloc::vec;
     use alloy_primitives::{address, hex, Bytes, Log, LogData, B256};
 
     #[test]

--- a/crates/genesis/src/updates/eip1559.rs
+++ b/crates/genesis/src/updates/eip1559.rs
@@ -59,6 +59,7 @@ impl TryFrom<&SystemConfigLog> for Eip1559Update {
 mod tests {
     use super::*;
     use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use alloc::vec;
     use alloy_primitives::{hex, Address, Bytes, Log, LogData, B256};
 
     #[test]

--- a/crates/genesis/src/updates/gas_config.rs
+++ b/crates/genesis/src/updates/gas_config.rs
@@ -74,6 +74,7 @@ impl TryFrom<&SystemConfigLog> for GasConfigUpdate {
 mod tests {
     use super::*;
     use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use alloc::vec;
     use alloy_primitives::{hex, uint, Address, Bytes, Log, LogData, B256};
 
     #[test]

--- a/crates/genesis/src/updates/gas_limit.rs
+++ b/crates/genesis/src/updates/gas_limit.rs
@@ -60,6 +60,7 @@ impl TryFrom<&SystemConfigLog> for GasLimitUpdate {
 mod tests {
     use super::*;
     use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use alloc::vec;
     use alloy_primitives::{hex, Address, Bytes, Log, LogData, B256};
 
     #[test]

--- a/crates/genesis/src/updates/operator_fee.rs
+++ b/crates/genesis/src/updates/operator_fee.rs
@@ -69,6 +69,7 @@ impl TryFrom<&SystemConfigLog> for OperatorFeeUpdate {
 mod tests {
     use super::*;
     use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use alloc::vec;
     use alloy_primitives::{hex, Address, Bytes, Log, LogData, B256};
 
     #[test]


### PR DESCRIPTION
### Description

Removes `std` restriction for `maili-genesis` tests.