### PR TITLE
fix(protocol): std leaking into tests

### DIFF
--- a/crates/protocol/src/batch/core.rs
+++ b/crates/protocol/src/batch/core.rs
@@ -74,6 +74,7 @@ impl Batch {
 mod tests {
     use super::*;
     use crate::{SpanBatchElement, SpanBatchError, SpanBatchTransactions};
+    use alloc::{vec, vec::Vec};
     use alloy_consensus::{Signed, TxEip2930, TxEnvelope};
     use alloy_primitives::{address, hex, Bytes, PrimitiveSignature as Signature, TxKind};
 

--- a/crates/protocol/src/batch/inclusion.rs
+++ b/crates/protocol/src/batch/inclusion.rs
@@ -47,6 +47,7 @@ impl BatchWithInclusionBlock {
 mod tests {
     use super::*;
     use crate::test_utils::TestBatchValidator;
+    use alloc::vec;
 
     #[tokio::test]
     async fn test_single_batch_with_inclusion_block() {

--- a/crates/protocol/src/batch/single.rs
+++ b/crates/protocol/src/batch/single.rs
@@ -175,6 +175,7 @@ impl SingleBatch {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use alloy_consensus::{SignableTransaction, TxEip1559, TxEip7702, TxEnvelope};
     use alloy_eips::eip2718::{Decodable2718, Encodable2718};
     use alloy_primitives::{Address, PrimitiveSignature, Sealed, TxKind, U256};

--- a/crates/protocol/src/batch/transactions.rs
+++ b/crates/protocol/src/batch/transactions.rs
@@ -350,6 +350,7 @@ impl SpanBatchTransactions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use alloy_consensus::{Signed, TxEip1559, TxEip2930, TxEip7702};
     use alloy_primitives::{address, PrimitiveSignature as Signature, TxKind};
 

--- a/crates/protocol/src/batch/tx_data/eip7702.rs
+++ b/crates/protocol/src/batch/tx_data/eip7702.rs
@@ -66,7 +66,7 @@ impl SpanBatchEip7702TransactionData {
 mod test {
     use super::*;
     use crate::SpanBatchTransactionData;
-    use alloc::vec::Vec;
+    use alloc::{vec, vec::Vec};
     use alloy_rlp::{Decodable, Encodable};
     use revm::primitives::Authorization;
 

--- a/crates/protocol/src/block.rs
+++ b/crates/protocol/src/block.rs
@@ -9,7 +9,7 @@ use op_alloy_consensus::OpBlock;
 
 /// Block Header Info
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Default)]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct BlockInfo {
@@ -78,7 +78,7 @@ pub struct L2BlockInfo {
     pub seq_num: u64,
 }
 
-#[cfg(any(test, feature = "arbitrary"))]
+#[cfg(feature = "arbitrary")]
 impl arbitrary::Arbitrary<'_> for L2BlockInfo {
     fn arbitrary(g: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self {
@@ -173,6 +173,7 @@ impl L2BlockInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
     use alloy_consensus::{Header, TxEnvelope};
     use alloy_primitives::b256;
 

--- a/crates/protocol/src/info/bedrock.rs
+++ b/crates/protocol/src/info/bedrock.rs
@@ -116,6 +116,7 @@ impl L1BlockInfoBedrock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_decode_calldata_bedrock_invalid_length() {

--- a/crates/protocol/src/info/ecotone.rs
+++ b/crates/protocol/src/info/ecotone.rs
@@ -151,6 +151,7 @@ impl L1BlockInfoEcotone {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_decode_calldata_ecotone_invalid_length() {

--- a/crates/protocol/src/info/interop.rs
+++ b/crates/protocol/src/info/interop.rs
@@ -134,6 +134,7 @@ impl L1BlockInfoInterop {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_decode_calldata_interop_invalid_length() {

--- a/crates/protocol/src/info/isthmus.rs
+++ b/crates/protocol/src/info/isthmus.rs
@@ -155,6 +155,7 @@ impl L1BlockInfoIsthmus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_decode_calldata_isthmus_invalid_length() {

--- a/crates/protocol/src/info/variant.rs
+++ b/crates/protocol/src/info/variant.rs
@@ -337,7 +337,7 @@ mod test {
     use crate::test_utils::{
         RAW_BEDROCK_INFO_TX, RAW_ECOTONE_INFO_TX, RAW_INTEROP_INFO_TX, RAW_ISTHMUS_INFO_TX,
     };
-    use alloc::string::ToString;
+    use alloc::{string::ToString, vec::Vec};
     use alloy_primitives::{address, b256};
 
     #[test]

--- a/crates/protocol/src/iter.rs
+++ b/crates/protocol/src/iter.rs
@@ -45,6 +45,7 @@ impl Iterator for FrameIter<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{vec, vec::Vec};
 
     #[test]
     fn test_iterate_none() {

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/crates/protocol/src/utils.rs
+++ b/crates/protocol/src/utils.rs
@@ -154,6 +154,7 @@ pub fn read_tx_data(r: &mut &[u8]) -> Result<(Vec<u8>, TxType), SpanBatchError> 
 mod tests {
     use super::*;
     use crate::test_utils::{RAW_BEDROCK_INFO_TX, RAW_ECOTONE_INFO_TX, RAW_ISTHMUS_INFO_TX};
+    use alloc::vec;
     use alloy_eips::eip1898::BlockNumHash;
     use alloy_primitives::{address, hex, uint, U256};
     use maili_genesis::ChainGenesis;
@@ -223,7 +224,6 @@ mod tests {
 
     #[test]
     fn test_to_system_config_non_deposit() {
-        use alloy_primitives::U256;
         let block = OpBlock {
             header: alloy_consensus::Header { number: 1, ..Default::default() },
             body: alloy_consensus::BlockBody {
@@ -235,7 +235,7 @@ mod tests {
                             gas_price: 1,
                             gas_limit: 1,
                             to: alloy_primitives::TxKind::Create,
-                            value: alloy_primitives::U256::ZERO,
+                            value: U256::ZERO,
                             input: alloy_primitives::Bytes::new(),
                         },
                         alloy_primitives::PrimitiveSignature::new(U256::ZERO, U256::ZERO, false),


### PR DESCRIPTION
### Description

Fixes the `maili-protocol` crate to not have `std` leaking into tests.

Closes #224