### PR TITLE
feat(protocol): implement brotli buffer for compressor

### DIFF
--- a/crates/protocol/src/compression/variant.rs
+++ b/crates/protocol/src/compression/variant.rs
@@ -11,7 +11,7 @@ use maili_genesis::RollupConfig;
 #[derive(Debug, Clone)]
 pub enum VariantCompressor {
     /// The brotli compressor.
-    Brotli(BrotliCompressor),
+    Brotli(Box<BrotliCompressor>),
     /// The zlib compressor.
     Zlib(ZlibCompressor),
 }
@@ -20,7 +20,7 @@ impl VariantCompressor {
     /// Constructs a [VariantCompressor] using the given [RollupConfig] and timestamp.
     pub fn from_timestamp(config: &RollupConfig, timestamp: u64) -> Self {
         if config.is_fjord_active(timestamp) {
-            Self::Brotli(BrotliCompressor::new(CompressionAlgo::Brotli10))
+            Self::Brotli(Box::new(BrotliCompressor::new(CompressionAlgo::Brotli10)))
         } else {
             Self::Zlib(ZlibCompressor::new())
         }
@@ -83,9 +83,9 @@ impl ChannelCompressor for VariantCompressor {
 impl From<CompressionAlgo> for VariantCompressor {
     fn from(algo: CompressionAlgo) -> Self {
         match algo {
-            lvl @ CompressionAlgo::Brotli9 => Self::Brotli(BrotliCompressor::new(lvl)),
-            lvl @ CompressionAlgo::Brotli10 => Self::Brotli(BrotliCompressor::new(lvl)),
-            lvl @ CompressionAlgo::Brotli11 => Self::Brotli(BrotliCompressor::new(lvl)),
+            lvl @ CompressionAlgo::Brotli9 => Self::Brotli(Box::new(BrotliCompressor::new(lvl))),
+            lvl @ CompressionAlgo::Brotli10 => Self::Brotli(Box::new(BrotliCompressor::new(lvl))),
+            lvl @ CompressionAlgo::Brotli11 => Self::Brotli(Box::new(BrotliCompressor::new(lvl))),
             CompressionAlgo::Zlib => Self::Zlib(ZlibCompressor::new()),
         }
     }


### PR DESCRIPTION
Fixes #176 

The implementation ended up being quite similar to #14. 

Note that one test fails: `compression::brotli::compress::test::test_compress_batch_brotli` but the roundtrip test (compresses, decompresses, and checks if we got the same data) passes. Perhaps we should just test roundtrips and not intermediate compressed vs expected? I assume because of the buffer we have the first few bits off.