### PR TITLE
chore(rpc): Interop Feat Flag Cleanup - Unused Dependency Warning Fix

### DIFF
--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -70,25 +70,27 @@ serde = [
 	"op-alloy-rpc-types-engine/serde",
 	"maili-interop?/serde"
 ]
-interop = [
-    "dep:thiserror",
-    "dep:maili-interop",
-    "dep:async-trait",
-]
 jsonrpsee = [
     "serde",
     "dep:maili-genesis",
     "dep:maili-interop",
     "dep:jsonrpsee",
     "dep:getrandom",
-    "dep:alloy-sol-types",
     "dep:op-alloy-rpc-jsonrpsee",
 ]
 client = [
+    "dep:tokio",
+    "dep:jsonrpsee",
     "dep:maili-interop",
-    "jsonrpsee",
     "jsonrpsee/client",
     "jsonrpsee/async-client",
     "op-alloy-rpc-jsonrpsee/client",
-    "tokio",
+]
+interop = [
+    "client",
+    "jsonrpsee",
+    "dep:thiserror",
+    "dep:maili-interop",
+    "dep:async-trait",
+    "dep:alloy-sol-types",
 ]

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -45,7 +45,7 @@ pub use api::{
     SupervisorApiServer,
 };
 
-#[cfg(all(feature = "jsonrpsee", feature = "client", feature = "interop"))]
+#[cfg(feature = "interop")]
 mod traits;
-#[cfg(all(feature = "jsonrpsee", feature = "client", feature = "interop"))]
+#[cfg(feature = "interop")]
 pub use traits::{ExecutingMessageValidator, ExecutingMessageValidatorError};


### PR DESCRIPTION
### Description

Fixes the unused dependency warning for `alloy_sol_types` by making the `interop` feature flag depend on `jsonrpsee` and `client`, which it effectively already does since interop traits cannot be used without all three features being enabled.

Closes #230